### PR TITLE
Add dependabot groups so we get less PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,11 @@ updates:
     schedule:
       interval: 'daily'
 
+    groups:
+      docker:
+        patterns:
+          - 'docker/*'
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -18,7 +23,7 @@ updates:
 
     # nhsuk-frontend needs to be updated in conjunction with nhsuk-frontend-jinja
     ignore:
-      - dependency-name: "nhsuk-frontend"
+      - dependency-name: 'nhsuk-frontend'
 
     groups:
       build:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,10 @@ updates:
     schedule:
       interval: 'daily'
 
+    # nhsuk-frontend needs to be updated in conjunction with nhsuk-frontend-jinja
+    ignore:
+      - dependency-name: "nhsuk-frontend"
+
     groups:
       build:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,10 +16,64 @@ updates:
     schedule:
       interval: 'daily'
 
+    groups:
+      build:
+        patterns:
+          - '@babel/*'
+          - '@rollup/*'
+          - 'rollup'
+          - 'rollup-*'
+          - 'sass-embedded'
+
+      lint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint'
+          - 'eslint-*'
+          - 'prettier'
+          - 'typescript'
+
+      test:
+        patterns:
+          - '@testing-library/*'
+          - 'babel-jest'
+          - 'jest'
+          - 'jest-*'
+
+      tools:
+        patterns:
+          - 'concurrently'
+
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
       interval: 'daily'
+
+    groups:
+      frontend:
+        patterns:
+          - jinja2
+          - nhsuk-frontend-jinja
+          - whitenoise
+
+      infra:
+        patterns:
+          - gunicorn
+          - azure-identity
+          - psycopg
+
+      lint_and_test:
+        patterns:
+          - ruff
+          - 'pytest*'
+          - '*playwright*'
+          - time-machine
+          - factory-boy
+
+      tools:
+        patterns:
+          - 'ipdb'
+          - 'dotenv'
 
   - package-ecosystem: 'terraform'
     directory: '/'

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,21 @@
 version: 2
 
+multi-ecosystem-groups:
+  templates:
+    schedule:
+      interval: weekly
+
 updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    patterns: ['nhsuk-frontend']
+    multi-ecosystem-group: templates
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    patterns: ['nhsuk-frontend-jinja']
+    multi-ecosystem-group: templates
+
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
@@ -58,11 +73,14 @@ updates:
     schedule:
       interval: 'daily'
 
+    ignore:
+      # nhsuk-frontend-jinja needs to be updated in conjunction with nhsuk-frontend
+      - dependency-name: nhsuk-frontend-jinja
+
     groups:
       frontend:
         patterns:
           - jinja2
-          - nhsuk-frontend-jinja
           - whitenoise
 
       infra:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,8 +21,8 @@ updates:
     schedule:
       interval: 'daily'
 
-    # nhsuk-frontend needs to be updated in conjunction with nhsuk-frontend-jinja
     ignore:
+      # nhsuk-frontend needs to be updated in conjunction with nhsuk-frontend-jinja
       - dependency-name: 'nhsuk-frontend'
 
     groups:
@@ -67,22 +67,22 @@ updates:
 
       infra:
         patterns:
-          - gunicorn
           - azure-identity
+          - gunicorn
           - psycopg
 
       lint_and_test:
         patterns:
-          - ruff
+          - factory-boy
           - 'pytest*'
           - '*playwright*'
+          - ruff
           - time-machine
-          - factory-boy
 
       tools:
         patterns:
-          - 'ipdb'
           - 'dotenv'
+          - 'ipdb'
 
   - package-ecosystem: 'terraform'
     directory: '/'


### PR DESCRIPTION
For NPM, use the same groups as nhsuk-frontend.

For pip, create the following groups:

- updates related to frontend assets and templates
- updates related to infrastructure concerns, i.e. updates that
  don't typically require code changes, but may still affect
  the running of the app in non-local environments
- updates related to testing and linting
- updates related to dev tools

We should also ignore nhsuk-frontend updates, because they are not actionable until nhsuk-frontend-jinja is updated.