### PR TITLE
Rename repo to include dtos- prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "manage-breast-screening-django-spike",
+  "name": "dtos-manage-breast-screening",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Since we belong to DTOS (digital transformation of screening), I've added the prefix to our repo name.

This gets reflected in the package-lock.json.
