### PR TITLE
Automatically order imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: v0.11.12
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ markers = ["system: mark a test as a system test"]
 
 [tool.ruff]
 exclude = ["*/migrations/*.py"]
+
+# On top of the defaults (`E4`, E7`, `E9`, and `F`), enable isort (`I`)
+select = ["E4", "E7", "E9", "F", "I"]


### PR DESCRIPTION
Ruff does not currently do this on format, but we can do it as part of the check if we pass --fix.

This change means that running the linter (or pre-commit hook) will automatically change files.

P.S. there are some more rulesets we could enable here, and I'm thinking it would be good to have a django specific one in particular, but I've left it out of this PR for now...

https://docs.astral.sh/ruff/rules/ 
