### PR TITLE
Increase timeout in clinic show page system test

### DIFF
--- a/manage_breast_screening/clinics/tests/system/test_user_views_clinic_show_page.py
+++ b/manage_breast_screening/clinics/tests/system/test_user_views_clinic_show_page.py
@@ -126,7 +126,9 @@ class TestUserViewsClinicShowPage(SystemTestCase):
 
     def then_the_appointment_is_checked_in(self):
         row = self.page.locator("tr").filter(has_text="Janet Confirmed")
-        expect(row.locator(".nhsuk-tag").filter(has_text="Checked in")).to_be_visible()
+        expect(row.locator(".nhsuk-tag").filter(has_text="Checked in")).to_be_visible(
+            timeout=10000
+        )
 
     def and_the_appointments_remain_in_the_same_order(self):
         self.when_i_click_on_all()


### PR DESCRIPTION

<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description
This system test is failing intermittently when checking the state of the page after clicking the check-in link.

To begin with, increase the timeout from 5s to 10s when looking for the state change. We can monitor this and see if further changes are needed to address the flakiness.

<!-- Add screenshots if there are any UI updates. -->

## Jira link
na
## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
na