### PR TITLE
Fix subnets

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -32,7 +32,7 @@ module "app-key-vault" {
   private_endpoint_properties = {
     private_dns_zone_ids_keyvault        = [data.azurerm_private_dns_zone.key-vault.id]
     private_endpoint_enabled             = true
-    private_endpoint_subnet_id           = module.container_app_subnet.id
+    private_endpoint_subnet_id           = module.main_subnet.id
     private_endpoint_resource_group_name = azurerm_resource_group.main.name
     private_service_connection_is_manual = false
   }

--- a/infrastructure/terraform/networking.tf
+++ b/infrastructure/terraform/networking.tf
@@ -80,6 +80,23 @@ module "container_app_subnet" {
   monitor_diagnostic_setting_network_security_group_enabled_logs = []
   log_analytics_workspace_id                                     = module.log_analytics_workspace_audit.id
   network_security_group_name                                    = "nsg-container-apps"
+  delegation_name                                                = "delegation"
+  service_delegation_name                                        = "Microsoft.App/environments"
+  service_delegation_actions                                     = ["Microsoft.Network/virtualNetworks/subnets/action"]
+}
+
+module "main_subnet" {
+  source = "../modules/dtos-devops-templates/infrastructure/modules/subnet"
+
+  name                                                           = "snet-main"
+  resource_group_name                                            = azurerm_resource_group.main.name
+  vnet_name                                                      = module.main_vnet.name
+  address_prefixes                                               = [cidrsubnet(var.vnet_address_space, 7, 2)]
+  create_nsg                                                     = false
+  location                                                       = "UK South"
+  monitor_diagnostic_setting_network_security_group_enabled_logs = []
+  log_analytics_workspace_id                                     = module.log_analytics_workspace_audit.id
+  network_security_group_name                                    = "nsg-container-apps"
 }
 
 data "azurerm_private_dns_zone" "key-vault" {


### PR DESCRIPTION
## Description
Fix error:
```
 Error: creating Managed Environment (Subscription: "67aab2fa-fcc7-49da-9dc6-cb90f0fa0628"
│ Resource Group Name: "rg-manbrs-dev-uks"
│ Managed Environment Name: "manage-breast-screening-dev"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: ManagedEnvironmentInvalidNetworkConfiguration: The environment network configuration is invalid: The delegated subnet cannot be used by any other Azure resources.
│ 
│   with module.container-app-environment.azurerm_container_app_environment.main,
│   on ../modules/dtos-devops-templates/infrastructure/modules/container-app-environment/main.tf line 1, in resource "azurerm_container_app_environment" "main":
│    1: resource "azurerm_container_app_environment" "main" {
│ 
│ creating Managed Environment (Subscription:
│ "67aab2fa-fcc7-49da-9dc6-cb90f0fa0628"
│ Resource Group Name: "rg-manbrs-dev-uks"
│ Managed Environment Name: "manage-breast-screening-dev"): performing
│ CreateOrUpdate: unexpected status 400 (400 Bad Request) with error:
│ ManagedEnvironmentInvalidNetworkConfiguration: The environment network
│ configuration is invalid: The delegated subnet cannot be used by any other
│ Azure resources.
```

The container app subnet must be only dedicated to container apps but the key vault private endpoint was created there.

We now create a "main" subnet to keep the private endpoint, and leave the container app subnet alone.

## Jira link
N/A

## Review notes
Test using `make dev terraform-apply`
<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
