### PR TITLE
[DTOSS-9247] Participant record appointments section

### DIFF
--- a/manage_breast_screening/mammograms/presenters.py
+++ b/manage_breast_screening/mammograms/presenters.py
@@ -4,27 +4,7 @@ from django.urls import reverse
 
 from ..core.utils.date_formatting import format_date, format_relative_date, format_time
 from ..participants.models import AppointmentStatus
-from ..participants.presenters import ParticipantPresenter
-
-
-def status_colour(status):
-    """
-    Color to render the status tag
-    """
-    match status:
-        case AppointmentStatus.CHECKED_IN:
-            return ""  # no colour will get solid dark blue
-        case AppointmentStatus.SCREENED:
-            return "green"
-        case AppointmentStatus.DID_NOT_ATTEND | AppointmentStatus.CANCELLED:
-            return "red"
-        case (
-            AppointmentStatus.ATTENDED_NOT_SCREENED
-            | AppointmentStatus.PARTIALLY_SCREENED
-        ):
-            return "orange"
-        case _:
-            return "blue"  # default blue
+from ..participants.presenters import ParticipantPresenter, status_colour
 
 
 def present_secondary_nav(id):

--- a/manage_breast_screening/participants/fixtures/participants.json
+++ b/manage_breast_screening/participants/fixtures/participants.json
@@ -86,9 +86,7 @@
       "date_of_birth": "1959-07-22",
       "ethnic_group": null,
       "risk_level": "Routine",
-      "extra_needs": [
-        "Wheelchair user"
-      ]
+      "extra_needs": ["Wheelchair user"]
     }
   },
   {

--- a/manage_breast_screening/participants/jinja2/participants/show.jinja
+++ b/manage_breast_screening/participants/jinja2/participants/show.jinja
@@ -1,7 +1,9 @@
 {% extends 'layout-app.jinja' %}
-{% from 'card/macro.jinja' import card %}
 {% from 'back-link/macro.jinja' import backLink %}
+{% from 'card/macro.jinja' import card %}
+{% from 'tag/macro.jinja' import tag %}
 {% from 'components/participant-details/macro.jinja' import participant_details %}
+{% from 'summary-list/macro.jinja' import summaryList %}
 
 {% block beforeContent %}
   {{ backLink({
@@ -18,13 +20,69 @@
       </h1>
 
       {% set personal_details_html %}
-        {{ participant_details(participant=participant, full_details=true, show_last_known_mammogram=false) }}
+        {{ participant_details(participant=presented_participant, full_details=true, show_last_known_mammogram=false) }}
       {% endset %}
 
       {{ card({
         "heading": "Personal details",
         "headingLevel": "2",
         "descriptionHtml": personal_details_html
+      }) }}
+
+      {% macro appointment_table(presented_appointments, testid) %}
+          <table class="nhsuk-table" data-testid="{{ testid }}">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Type</th>
+              <th>Location</th>
+              <th>Status</th>
+              <th>Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for presented_appointment in presented_appointments %}
+              <tr data-testid="appointment-row">
+                <td>{{ presented_appointment.starts_at }}</td>
+                <td>{{ presented_appointment.clinic_type }}</td>
+                <td>{{ presented_appointment.setting_name }}</td>
+                <td>
+                  {{ tag({
+                    "text": presented_appointment.status.text,
+                    "classes": presented_appointment.status.classes
+                  }) }}
+                </td>
+                <td>
+                  <a href="{{ presented_appointment.url }}">
+                    View details
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+          </table>
+      {% endmacro %}
+
+      {% set appointments_html %}
+        {% if presented_appointments.upcoming %}
+          <h3>Upcoming</h3>
+          {{ appointment_table(presented_appointments.upcoming, testid="upcoming-appointments-table") }}
+        {% endif %}
+
+        {% if presented_appointments.past %}
+          <h3>Previous</h3>
+          {{ appointment_table(presented_appointments.past, testid="past-appointments-table") }}
+        {% endif %}
+
+        {% if not presented_appointments.past and not presented_appointments.upcoming %}
+          <p>No screening history found</p>
+        {% endif %}
+      {% endset %}
+
+      {{ card({
+        "heading": "Appointments",
+        "headingLevel": "2",
+        "descriptionHtml": appointments_html
       }) }}
     </div>
   </div>

--- a/manage_breast_screening/participants/models.py
+++ b/manage_breast_screening/participants/models.py
@@ -149,6 +149,12 @@ class AppointmentQuerySet(models.QuerySet):
             AppointmentStatus.ATTENDED_NOT_SCREENED,
         )
 
+    def upcoming(self):
+        return self.filter(clinic_slot__starts_at__gte=date.today())
+
+    def past(self):
+        return self.filter(clinic_slot__starts_at__lt=date.today())
+
     def for_clinic_and_filter(self, clinic, filter):
         match filter:
             case "remaining":

--- a/manage_breast_screening/participants/tests/factories.py
+++ b/manage_breast_screening/participants/tests/factories.py
@@ -59,6 +59,15 @@ class AppointmentFactory(DjangoModelFactory):
     clinic_slot = SubFactory(ClinicSlotFactory)
     screening_episode = SubFactory(ScreeningEpisodeFactory)
 
+    @post_generation
+    def starts_at(obj, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+
+        obj.clinic_slot.starts_at = extracted
+        if create:
+            obj.clinic_slot.save()
+
     # Allow passing an explicit status
     # e.g. `current_status=AppointmentStatus.CHECKED_IN`
     @post_generation

--- a/manage_breast_screening/participants/tests/system/test_participant_record.py
+++ b/manage_breast_screening/participants/tests/system/test_participant_record.py
@@ -1,9 +1,12 @@
 import re
+from datetime import datetime
+from datetime import timezone as tz
 
 import pytest
 from django.urls import reverse
 from playwright.sync_api import expect
 
+from manage_breast_screening.clinics.tests.factories import ClinicSlotFactory
 from manage_breast_screening.core.system_test_setup import SystemTestCase
 from manage_breast_screening.participants.tests.factories import (
     AppointmentFactory,
@@ -14,14 +17,15 @@ from manage_breast_screening.participants.tests.factories import (
 
 class TestParticipantRecord(SystemTestCase):
     @pytest.fixture(autouse=True)
-    def before(self):
+    def before(self, time_machine):
         self.participant = ParticipantFactory(first_name="Janet", last_name="Williams")
-        self.screening_episode = ScreeningEpisodeFactory(participant=self.participant)
-        self.appointment = AppointmentFactory(screening_episode=self.screening_episode)
+
+        time_machine.move_to(datetime(2025, 1, 1, 10, tzinfo=tz.utc))
 
     @pytest.mark.skip("not implemented yet")
     def test_viewing_participant_record_from_an_appointment(self):
-        self.given_i_am_viewing_an_appointment()
+        self.given_i_have_an_upcoming_appointment()
+        self.given_i_am_viewing_the_upcoming_appointment()
         self.when_i_click_on_view_participant_record()
         self.then_i_should_be_on_the_participant_record_page()
         self.and_i_should_see_the_participant_record()
@@ -32,12 +36,53 @@ class TestParticipantRecord(SystemTestCase):
         self.given_i_am_on_the_participant_record_page()
         self.then_the_accessibility_baseline_is_met()
 
-    def given_i_am_viewing_an_appointment(self):
+    def test_viewing_upcoming_appointments(self):
+        self.given_i_have_an_upcoming_appointment()
+        self.and_i_am_on_the_participant_record_page()
+        self.then_i_should_see_the_upcoming_appointment()
+        self.when_i_click_on_the_upcoming_appointment()
+        self.then_i_should_be_on_the_upcoming_appointment_page()
+
+    def test_viewing_past_appointments(self):
+        self.given_i_have_past_appointments()
+        self.and_i_am_on_the_participant_record_page()
+        self.then_i_should_see_the_past_appointments()
+        self.when_i_click_on_a_past_appointment()
+        self.then_i_should_be_on_the_past_appointment_page()
+
+    def given_i_have_an_upcoming_appointment(self):
+        clinic_slot = ClinicSlotFactory(
+            starts_at=datetime(2025, 1, 2, 11, tzinfo=tz.utc)
+        )
+        screening_episode = ScreeningEpisodeFactory(participant=self.participant)
+        self.upcoming_appointment = AppointmentFactory(
+            clinic_slot=clinic_slot, screening_episode=screening_episode
+        )
+
+    def given_i_have_past_appointments(self):
+        clinic_slot_2022 = ClinicSlotFactory(
+            starts_at=datetime(2022, 1, 2, 11, tzinfo=tz.utc)
+        )
+        clinic_slot_2019 = ClinicSlotFactory(
+            starts_at=datetime(2019, 1, 2, 11, tzinfo=tz.utc)
+        )
+        self.past_appointments = [
+            AppointmentFactory(
+                clinic_slot=clinic_slot_2022,
+                screening_episode=ScreeningEpisodeFactory(participant=self.participant),
+            ),
+            AppointmentFactory(
+                clinic_slot=clinic_slot_2019,
+                screening_episode=ScreeningEpisodeFactory(participant=self.participant),
+            ),
+        ]
+
+    def given_i_am_viewing_the_upcoming_appointment(self):
         self.page.goto(
             self.live_server_url
             + reverse(
                 "mammograms:start_screening",
-                kwargs={"id": self.appointment.pk},
+                kwargs={"id": self.upcoming_appointment.pk},
             )
         )
 
@@ -49,6 +94,8 @@ class TestParticipantRecord(SystemTestCase):
                 kwargs={"pk": self.participant.pk},
             )
         )
+
+    and_i_am_on_the_participant_record_page = given_i_am_on_the_participant_record_page
 
     def when_i_click_on_view_participant_record(self):
         self.page.get_by_text("View participant record").click()
@@ -71,6 +118,44 @@ class TestParticipantRecord(SystemTestCase):
     def then_i_should_be_back_on_the_appointment(self):
         path = reverse(
             "mammograms:start_screening",
-            kwargs={"id": self.appointment.pk},
+            kwargs={"id": self.upcoming_appointment.pk},
+        )
+        expect(self.page).to_have_url(re.compile(path))
+
+    def then_i_should_see_the_upcoming_appointment(self):
+        upcoming = self.page.get_by_test_id("upcoming-appointments-table")
+        expect(upcoming).to_be_visible()
+        appointment = upcoming.get_by_test_id("appointment-row")
+        expect(appointment).to_be_visible()
+        expect(appointment).to_contain_text("2 January 2025")
+
+    def then_i_should_see_the_past_appointments(self):
+        past = self.page.get_by_test_id("past-appointments-table")
+        expect(past).to_be_visible()
+        appointments = past.get_by_test_id("appointment-row").all()
+        assert len(appointments) == 2
+
+        expect(appointments[0]).to_contain_text("2 January 2022")
+        expect(appointments[1]).to_contain_text("2 January 2019")
+
+    def when_i_click_on_the_upcoming_appointment(self):
+        past = self.page.get_by_test_id("upcoming-appointments-table")
+        past.get_by_text("View details").click()
+
+    def when_i_click_on_a_past_appointment(self):
+        past = self.page.get_by_test_id("past-appointments-table")
+        past.get_by_text("View details").first.click()
+
+    def then_i_should_be_on_the_past_appointment_page(self):
+        path = reverse(
+            "mammograms:start_screening",
+            kwargs={"id": self.past_appointments[0].pk},
+        )
+        expect(self.page).to_have_url(re.compile(path))
+
+    def then_i_should_be_on_the_upcoming_appointment_page(self):
+        path = reverse(
+            "mammograms:start_screening",
+            kwargs={"id": self.upcoming_appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))

--- a/manage_breast_screening/participants/tests/system/test_participant_record.py
+++ b/manage_breast_screening/participants/tests/system/test_participant_record.py
@@ -24,7 +24,7 @@ class TestParticipantRecord(SystemTestCase):
 
     @pytest.mark.skip("not implemented yet")
     def test_viewing_participant_record_from_an_appointment(self):
-        self.given_i_have_an_upcoming_appointment()
+        self.given_the_participant_has_an_upcoming_appointment()
         self.given_i_am_viewing_the_upcoming_appointment()
         self.when_i_click_on_view_participant_record()
         self.then_i_should_be_on_the_participant_record_page()
@@ -37,7 +37,7 @@ class TestParticipantRecord(SystemTestCase):
         self.then_the_accessibility_baseline_is_met()
 
     def test_viewing_upcoming_appointments(self):
-        self.given_i_have_an_upcoming_appointment()
+        self.given_the_participant_has_an_upcoming_appointment()
         self.and_i_am_on_the_participant_record_page()
         self.then_i_should_see_the_upcoming_appointment()
         self.when_i_click_on_the_upcoming_appointment()
@@ -50,7 +50,7 @@ class TestParticipantRecord(SystemTestCase):
         self.when_i_click_on_a_past_appointment()
         self.then_i_should_be_on_the_past_appointment_page()
 
-    def given_i_have_an_upcoming_appointment(self):
+    def given_the_participant_has_an_upcoming_appointment(self):
         clinic_slot = ClinicSlotFactory(
             starts_at=datetime(2025, 1, 2, 11, tzinfo=tz.utc)
         )

--- a/manage_breast_screening/participants/tests/test_presenters.py
+++ b/manage_breast_screening/participants/tests/test_presenters.py
@@ -1,13 +1,16 @@
 from datetime import date, datetime
 from datetime import timezone as tz
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
-from manage_breast_screening.participants.presenters import ParticipantPresenter
+from manage_breast_screening.participants.presenters import (
+    ParticipantAppointmentsPresenter,
+    ParticipantPresenter,
+)
 
-from ..models import Participant
+from ..models import Appointment, AppointmentStatus, Participant
 
 
 class TestParticipantPresenter:
@@ -65,3 +68,92 @@ class TestParticipantPresenter:
         assert result.age == "70 years old"
         assert result.risk_level == ""
         assert result.url == f"/participants/{mock_participant.pk}/"
+
+
+class TestParticipantAppointmentPresenter:
+    def mock_appointment(self, starts_at, pk, state=AppointmentStatus.CONFIRMED):
+        appointment = MagicMock(spec=Appointment)
+        appointment.clinic_slot.starts_at = starts_at
+        appointment.clinic_slot.clinic.get_type_display.return_value = "screening"
+        appointment.clinic_slot.clinic.setting.name = "West of London BSS"
+        appointment.pk = UUID(pk)
+        appointment.current_status = AppointmentStatus(state=state)
+
+        return appointment
+
+    @pytest.fixture
+    def upcoming_appointments(self):
+        return [
+            self.mock_appointment(
+                starts_at=datetime(2025, 1, 1, 9, tzinfo=tz.utc),
+                pk="e3d475a6-c405-44d6-bbd7-bcb5cd4d4996",
+            )
+        ]
+
+    @pytest.fixture
+    def past_appointments(self):
+        return [
+            self.mock_appointment(
+                starts_at=datetime(2023, 1, 1, 9, tzinfo=tz.utc),
+                pk="e76163c8-a594-4991-890d-a02097c67a2f",
+                state=AppointmentStatus.PARTIALLY_SCREENED,
+            ),
+            self.mock_appointment(
+                starts_at=datetime(2019, 1, 1, 9, tzinfo=tz.utc),
+                pk="6473a629-e7c4-43ca-87f3-ab9526aab07c",
+                state=AppointmentStatus.SCREENED,
+            ),
+        ]
+
+    def test_upcoming(self, upcoming_appointments, past_appointments, time_machine):
+        time_machine.move_to(datetime(2025, 1, 1, 9, tzinfo=tz.utc))
+
+        presenter = ParticipantAppointmentsPresenter(
+            past_appointments=past_appointments,
+            upcoming_appointments=upcoming_appointments,
+        )
+        assert presenter.upcoming == [
+            ParticipantAppointmentsPresenter.PresentedAppointment(
+                "1 January 2025",
+                "Screening",
+                "West of London BSS",
+                {
+                    "classes": "nhsuk-tag--blue app-nowrap",
+                    "key": "CONFIRMED",
+                    "text": "Confirmed",
+                },
+                "/mammograms/e3d475a6-c405-44d6-bbd7-bcb5cd4d4996/start-screening/",
+            )
+        ]
+
+    def test_past(self, upcoming_appointments, past_appointments, time_machine):
+        time_machine.move_to(datetime(2025, 1, 1, 9, tzinfo=tz.utc))
+
+        presenter = ParticipantAppointmentsPresenter(
+            past_appointments=past_appointments,
+            upcoming_appointments=upcoming_appointments,
+        )
+        assert presenter.past == [
+            ParticipantAppointmentsPresenter.PresentedAppointment(
+                "1 January 2023",
+                "Screening",
+                "West of London BSS",
+                {
+                    "classes": "nhsuk-tag--orange app-nowrap",
+                    "key": "PARTIALLY_SCREENED",
+                    "text": "Partially screened",
+                },
+                "/mammograms/e76163c8-a594-4991-890d-a02097c67a2f/start-screening/",
+            ),
+            ParticipantAppointmentsPresenter.PresentedAppointment(
+                "1 January 2019",
+                "Screening",
+                "West of London BSS",
+                {
+                    "classes": "nhsuk-tag--green app-nowrap",
+                    "key": "SCREENED",
+                    "text": "Screened",
+                },
+                "/mammograms/6473a629-e7c4-43ca-87f3-ab9526aab07c/start-screening/",
+            ),
+        ]

--- a/manage_breast_screening/participants/views.py
+++ b/manage_breast_screening/participants/views.py
@@ -3,21 +3,33 @@ from logging import getLogger
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from .models import Participant
-from .presenters import ParticipantPresenter
+from .models import Appointment, Participant
+from .presenters import ParticipantAppointmentsPresenter, ParticipantPresenter
 
 logger = getLogger(__name__)
 
 
 def show(request, pk):
     participant = get_object_or_404(Participant, pk=pk)
-    presenter = ParticipantPresenter(participant)
+    presented_participant = ParticipantPresenter(participant)
+
+    appointments = (
+        Appointment.objects.select_related("clinic_slot__clinic__setting")
+        .filter(screening_episode__participant=participant)
+        .order_by("-clinic_slot__starts_at")
+    )
+
+    presented_appointments = ParticipantAppointmentsPresenter(
+        past_appointments=list(appointments.past()),
+        upcoming_appointments=list(appointments.upcoming()),
+    )
 
     return render(
         request,
         "participants/show.jinja",
         context={
-            "participant": presenter,
+            "presented_participant": presented_participant,
+            "presented_appointments": presented_appointments,
             "heading": participant.full_name,
             "back_link": {
                 "text": "Back to participants",


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Display upcoming and past appointments on the participant record, to match the prototype.

Note that the design changed since we created the Jira ticket. We decided to focus just on appointments, rather than screening episodes, until we have a better understanding of what information would be useful to show at the level of a screening episode. We are also not yet showing any mammogram events that do not relate to the national breast screening programme.

If a section is empty, it is not shown, and if neither section is populated then we show "No screening history found".

![Screenshot showing upcoming appointments](https://github.com/user-attachments/assets/2d5db88c-cb07-4118-8921-86f316852943)
![Screenshot showing past appointments](https://github.com/user-attachments/assets/bea6308b-d883-4ebc-8bd4-99e14052586f)

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9247

## Review notes

There is a column in the design for type, but this is always "Screening" at the moment. Do we want to drop this?

It would be good to have some feedback on the tests, particularly the playwright ones.
- have I hit the right balance with the scenarios? I want to make sure the happy paths are covered but don't want these tests to get so large that they take ages to run
- are there any improvements that could be made to the assertions in the "then" steps?