### PR TITLE
Speed up playwright browser install in CI

### DIFF
--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -68,8 +68,27 @@ jobs:
       - name: Install dependencies
         run: make dependencies
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo -n "::set-output name=version::$(poetry show playwright | awk '/version/ { print $3 }')"
+
+      - name: Install Playwright dependencies
+        run: poetry run playwright install-deps
+
+      - name: Cache playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4.2.3
+        with:
+          # Use faster GNU tar for all runners
+          enableCrossOsArchive: true
+          path: '~/.cache/ms-playwright'
+          key: '${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}'
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
-        run: poetry run playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: poetry run playwright install chromium --only-shell
 
       - name: 'Run unit test suite'
         run: make test-unit


### PR DESCRIPTION
We run playwright against every commit, but this currently involves a step of installing browsers, which takes almost 30 seconds.

This can be optimised by

1. only installing headless chrome
2. caching .ms-playwright so we don't need to download the same browser again if the version of playwright hasn't changed

This is based on the suggestions in this thread:
https://github.com/microsoft/playwright/issues/7249

Some people have pointed out that the system deps installed via --install-deps may interfere with restoring from cache. To avoid this I've split out this out into a separate install-deps step.