### PR TITLE
Exclude notifications models from ERD generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
         language: system
         pass_filenames: false
         files: '.*models\.py$|.*models/.*\.py$'
-        
+        exclude: '.*\/notifications\/models\.py$'
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.11.12


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

django-diagrams doesn't seem to handle duplicate model names. An error is thrown from the githook. 
Exclude notifications models for now.

<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
