### PR TITLE
Fix asdf nodejs version identifier

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 pre-commit 3.6.0
 python 3.13.2
-nodejs v22.14.0
+nodejs 22.14.0
 
 # TODO: can we switch all these docker scripts to github actions instead? Or at least something that
 # will be maintained by Dependabot?


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

The `v` prefix in `nodejs v22.14.0` does not work on Linux, I have verified that other OSes call `asdf install` successfully without this prefix.
<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

Does `asdf install` work for your OS?
<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
