### PR TITLE
Move mesh client test and skip temporarily

### DIFF
--- a/manage_breast_screening/notifications/tests/test_mesh_client.py
+++ b/manage_breast_screening/notifications/tests/test_mesh_client.py
@@ -1,6 +1,7 @@
 # Create your tests here.
 
 
+import pytest
 from mesh_client import MeshClient
 
 base_uri = "http://localhost:8700"  # Replace with your actual base URI
@@ -9,6 +10,9 @@ _PASSWORD = "Password"
 _SHARED_KEY = "Testkey"
 
 
+@pytest.mark.skip(
+    reason="This test depends on mesh-sandbox running in another container"
+)
 def test_get_file():
     with MeshClient(
         url=base_uri,


### PR DESCRIPTION
## Description
There's a dependency on having a MESH sandbox running in a container for this test to work properly.

- Move `tests.py` to avoid module name collision with `manage_breast_screening.notifications.tests`
- Skip test until we have container for MESH running as part of CI setup.
<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
