### PR TITLE
DTOSS-9812 Appointment completed page

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -31,7 +31,7 @@ h3 {
 Highlight in red links that don't get anywhere yet
 */
 a[href="#"] {
-  color: #c80000;
+  color: #c80000 !important;
 }
 
 // Status tag positioning within headers

--- a/manage_breast_screening/clinics/jinja2/clinics/show.jinja
+++ b/manage_breast_screening/clinics/jinja2/clinics/show.jinja
@@ -46,7 +46,7 @@
   {% for presented_appointment in presented_appointment_list.appointments %}
     {% set details_html %}
       <p class="nhsuk-u-margin-bottom-1">
-        <a href="{{ url('mammograms:start_screening', kwargs={"pk": presented_appointment.pk}) }}" class="nhsuk-link">
+        <a href="{{ url('mammograms:show_appointment', kwargs={"pk": presented_appointment.pk}) }}" class="nhsuk-link">
           {{ presented_appointment.participant.full_name }}
         </a>
       </p>

--- a/manage_breast_screening/core/jinja2/components/appointment-header/template.jinja
+++ b/manage_breast_screening/core/jinja2/components/appointment-header/template.jinja
@@ -3,6 +3,6 @@
 
 <p class="app-text-grey"><span>NHS Number: {{ participant.nhs_number }}</span></p>
 
-<p>{{ clinic_slot.slot_time_and_clinic_date }}<span class="nhsuk-u-margin-left-3"><a href="#">Reschedule appointment</a></span></p>
+<p>{{ clinic_slot.slot_time_and_clinic_date }}{% if not appointment.current_status.is_screened %}<span class="nhsuk-u-margin-left-3"><a href="#">Reschedule appointment</a></span>{% endif %}</p>
 
 <p class="nhsuk-u-margin-bottom-4"><a href="{{ appointment.participant_url }}">View participant record</a></p>

--- a/manage_breast_screening/mammograms/jinja2/mammograms/show/appointment_details.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/show/appointment_details.jinja
@@ -1,12 +1,23 @@
-{% extends "wizard_step.jinja" %}
+{% extends 'layout-app.jinja' %}
 {% from 'card/macro.jinja' import card %}
 {% from 'warning-callout/macro.jinja' import warningCallout %}
+{% from 'back-link/macro.jinja' import backLink %}
 {% from 'components/appointment-status/macro.jinja' import appointment_status %}
 {% from 'components/appointment-header/macro.jinja' import appointment_header %}
 {% from 'components/participant-details/macro.jinja' import participant_details %}
 {% from 'components/secondary-navigation/macro.jinja' import app_secondary_navigation %}
 
-{% block heading %}
+{% block beforeContent %}
+{{ backLink({
+  "href": presented_appointment.clinic_url,
+  "text": "Back to clinic"
+}) }}
+{% endblock beforeContent %}
+
+{% block page_content %}
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+
   <div class="app-header">
     <h1 class="nhsuk-heading-l">
       <span class="nhsuk-caption-l">
@@ -22,30 +33,13 @@
       )}}
     </div>
   </div>
-{% endblock %}
 
-{% block step_content %}
   {{ appointment_header(presented_appointment) }}
 
-  {% set special_appointment_html %}
-    {% if presented_participant.extra_needs | length > 1 %}
-      <ul>
-        {% for need in presented_participant.extra_needs %}
-          <li>{{need}}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p>{{ presented_participant.extra_needs | first }}</p>
-    {% endif %}
-    <p><a href="#">Change</a></p>
-  {% endset %}
-
-  {% if presented_participant.extra_needs %}
-    {{ warningCallout({
-      "heading": "Special appointment",
-      "HTML": special_appointment_html
-    }) }}
-  {% endif %}
+  {{ app_secondary_navigation({
+    "visuallyHiddenTitle": "Secondary menu",
+    "items": secondary_nav_items
+  }) }}
 
   {{ card({
     "headingHtml": " ",
@@ -57,4 +51,6 @@
       screening_protocol=presented_appointment.screening_protocol
     )
   }) }}
+  </div>
+</div>
 {% endblock %}

--- a/manage_breast_screening/mammograms/presenters.py
+++ b/manage_breast_screening/mammograms/presenters.py
@@ -69,6 +69,7 @@ class AppointmentPresenter:
             "text": current_status.get_state_display(),
             "key": current_status.state,
             "is_confirmed": current_status.state == AppointmentStatus.CONFIRMED,
+            "is_screened": current_status.state == AppointmentStatus.SCREENED,
         }
 
 

--- a/manage_breast_screening/mammograms/presenters.py
+++ b/manage_breast_screening/mammograms/presenters.py
@@ -40,6 +40,10 @@ class AppointmentPresenter:
         return self.participant.url
 
     @cached_property
+    def clinic_url(self):
+        return self.clinic_slot.clinic_url
+
+    @cached_property
     def start_time(self):
         return self.clinic_slot.starts_at
 
@@ -148,6 +152,10 @@ class ClinicSlotPresenter:
     @cached_property
     def clinic_type(self):
         return self._clinic.get_type_display().capitalize()
+
+    @cached_property
+    def clinic_url(self):
+        return reverse("clinics:show", kwargs={"pk": self._clinic.pk})
 
     @cached_property
     def slot_time_and_clinic_date(self):

--- a/manage_breast_screening/mammograms/presenters.py
+++ b/manage_breast_screening/mammograms/presenters.py
@@ -15,7 +15,7 @@ def present_secondary_nav(pk):
         {
             "id": "all",
             "text": "Appointment details",
-            "href": reverse("mammograms:start_screening", kwargs={"pk": pk}),
+            "href": reverse("mammograms:show_appointment", kwargs={"pk": pk}),
             "current": True,
         },
         {"id": "medical_information", "text": "Medical information", "href": "#"},

--- a/manage_breast_screening/mammograms/tests/system/test_adding_previous_mammograms.py
+++ b/manage_breast_screening/mammograms/tests/system/test_adding_previous_mammograms.py
@@ -24,7 +24,7 @@ class TestAddingPreviousMammograms(SystemTestCase):
         """
         If a mammogram was taken at the same provider, but there is an error in the system, the participant can report that it was taken.
         """
-        self.given_i_am_on_the_start_screening_page()
+        self.given_i_am_on_the_appointment_show_page()
         self.then_i_should_see_no_reported_mammograms()
 
         self.when_i_click_on_add_mammogram()
@@ -43,7 +43,7 @@ class TestAddingPreviousMammograms(SystemTestCase):
         If a mammogram was taken at another BSU, or elsewhere in the UK, the participant can report that it was taken
         If the mammogram was taken under a different name, the mammographer can record that name.
         """
-        self.given_i_am_on_the_start_screening_page()
+        self.given_i_am_on_the_appointment_show_page()
         self.then_i_should_see_no_reported_mammograms()
 
         self.when_i_click_on_add_mammogram()
@@ -61,11 +61,11 @@ class TestAddingPreviousMammograms(SystemTestCase):
         self.given_i_am_on_the_add_previous_mammograms_page()
         self.then_the_accessibility_baseline_is_met()
 
-    def given_i_am_on_the_start_screening_page(self):
+    def given_i_am_on_the_appointment_show_page(self):
         self.page.goto(
             self.live_server_url
             + reverse(
-                "mammograms:start_screening",
+                "mammograms:show_appointment",
                 kwargs={"pk": self.appointment.pk},
             )
         )
@@ -94,7 +94,7 @@ class TestAddingPreviousMammograms(SystemTestCase):
 
     def then_i_should_be_back_on_the_appointment(self):
         path = reverse(
-            "mammograms:start_screening",
+            "mammograms:show_appointment",
             kwargs={"pk": self.appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))

--- a/manage_breast_screening/mammograms/tests/system/test_recording_a_mammogram.py
+++ b/manage_breast_screening/mammograms/tests/system/test_recording_a_mammogram.py
@@ -23,7 +23,7 @@ class TestRecordingAMammogram(SystemTestCase):
         """
         I can record a mammogram without entering any relevant medical information.
         """
-        self.given_i_am_on_the_start_screening_page()
+        self.given_i_am_on_the_appointment_show_page()
         self.then_i_should_see_the_demographic_banner()
         self.and_i_should_see_the_participant_details()
 
@@ -39,7 +39,7 @@ class TestRecordingAMammogram(SystemTestCase):
         At each step in the flow, when I fill out the forms incorrectly,
         then I should see the errors so I can fix them.
         """
-        self.given_i_am_on_the_start_screening_page()
+        self.given_i_am_on_the_appointment_show_page()
         self.when_i_submit_the_form()
         self.then_i_am_prompted_to_answer_can_the_screening_go_ahead()
 
@@ -56,7 +56,7 @@ class TestRecordingAMammogram(SystemTestCase):
         self.then_i_am_prompted_to_confirm_whether_imaging_can_go_ahead()
 
     def test_accessibility(self):
-        self.given_i_am_on_the_start_screening_page()
+        self.given_i_am_on_the_appointment_show_page()
         self.then_the_accessibility_baseline_is_met()
 
         self.when_i_check_the_participants_identity_and_confirm_the_last_mammogram_date()
@@ -68,11 +68,11 @@ class TestRecordingAMammogram(SystemTestCase):
         self.when_i_mark_that_imaging_can_go_ahead()
         self.then_the_accessibility_baseline_is_met()
 
-    def given_i_am_on_the_start_screening_page(self):
+    def given_i_am_on_the_appointment_show_page(self):
         self.page.goto(
             self.live_server_url
             + reverse(
-                "mammograms:start_screening",
+                "mammograms:show_appointment",
                 kwargs={"pk": self.appointment.pk},
             )
         )

--- a/manage_breast_screening/mammograms/tests/system/test_viewing_a_completed_appointment.py
+++ b/manage_breast_screening/mammograms/tests/system/test_viewing_a_completed_appointment.py
@@ -1,0 +1,56 @@
+import pytest
+from django.urls import reverse
+from playwright.sync_api import expect
+
+from manage_breast_screening.core.system_test_setup import SystemTestCase
+from manage_breast_screening.participants.models import AppointmentStatus
+from manage_breast_screening.participants.tests.factories import (
+    AppointmentFactory,
+    ParticipantFactory,
+    ScreeningEpisodeFactory,
+)
+
+
+class TestViewingACompletedAppointment(SystemTestCase):
+    @pytest.fixture(autouse=True)
+    def before(self):
+        self.participant = ParticipantFactory(first_name="Janet", last_name="Williams")
+        self.screening_episode = ScreeningEpisodeFactory(participant=self.participant)
+        self.appointment = AppointmentFactory(
+            screening_episode=self.screening_episode,
+            current_status=AppointmentStatus.SCREENED,
+        )
+
+    def test_viewing_a_completed_appointment(self):
+        """
+        The appointment page includes appointment details, medical information, and images tabs.
+        Only the first one is implemented yet.
+        """
+        self.given_i_am_on_the_appointment_show_page()
+        self.then_i_should_see_the_demographic_banner()
+        self.and_i_should_see_the_participant_details()
+        self.and_i_should_not_see_a_form()
+
+    def test_accessibility(self):
+        self.given_i_am_on_the_appointment_show_page()
+        self.then_the_accessibility_baseline_is_met()
+
+    def given_i_am_on_the_appointment_show_page(self):
+        self.page.goto(
+            self.live_server_url
+            + reverse(
+                "mammograms:show_appointment",
+                kwargs={"pk": self.appointment.pk},
+            )
+        )
+
+    def then_i_should_see_the_demographic_banner(self):
+        expect(self.page.get_by_text("NHS Number")).to_be_visible()
+
+    def and_i_should_see_the_participant_details(self):
+        expect(
+            self.page.locator(".nhsuk-summary-list__row", has_text="Full name")
+        ).to_contain_text("Janet Williams")
+
+    def and_i_should_not_see_a_form(self):
+        expect(self.page.get_by_role("form")).not_to_be_attached()

--- a/manage_breast_screening/mammograms/tests/test_presenters.py
+++ b/manage_breast_screening/mammograms/tests/test_presenters.py
@@ -133,7 +133,7 @@ class TestLastKnownMammogramPresenter:
         result = LastKnownMammogramPresenter(
             [],
             participant_pk=uuid4(),
-            current_url="/mammograms/start-screening/abc",
+            current_url="/mammograms/abc",
         )
 
         assert result.last_known_mammograms == []
@@ -143,7 +143,7 @@ class TestLastKnownMammogramPresenter:
         result = LastKnownMammogramPresenter(
             [reported_today],
             participant_pk=uuid4(),
-            current_url="/mammograms/start-screening/abc",
+            current_url="/mammograms/abc",
         )
 
         assert result.last_known_mammograms == [
@@ -165,7 +165,7 @@ class TestLastKnownMammogramPresenter:
         result = LastKnownMammogramPresenter(
             [reported_today, reported_earlier],
             participant_pk=uuid4(),
-            current_url="/mammograms/start-screening/abc",
+            current_url="/mammograms/abc",
         )
 
         assert result.last_known_mammograms == [
@@ -193,7 +193,7 @@ class TestLastKnownMammogramPresenter:
 
     def test_add_link(self, reported_today):
         participant_id = uuid4()
-        current_url = "/mammograms/start-screening/abc"
+        current_url = "/mammograms/abc"
 
         result = LastKnownMammogramPresenter(
             [reported_today],

--- a/manage_breast_screening/mammograms/tests/test_presenters.py
+++ b/manage_breast_screening/mammograms/tests/test_presenters.py
@@ -29,7 +29,7 @@ class TestAppointmentPresenter:
         return mock
 
     @pytest.mark.parametrize(
-        "status, expected_classes, expected_text, expected_key, expected_is_confirmed",
+        "status, expected_classes, expected_text, expected_key, expected_is_confirmed, expected_is_screened",
         [
             (
                 AppointmentStatus.CONFIRMED,
@@ -37,12 +37,14 @@ class TestAppointmentPresenter:
                 "Confirmed",
                 "CONFIRMED",
                 True,
+                False,
             ),
             (
                 AppointmentStatus.CHECKED_IN,
                 "app-nowrap",
                 "Checked in",
                 "CHECKED_IN",
+                False,
                 False,
             ),
             (
@@ -51,6 +53,15 @@ class TestAppointmentPresenter:
                 "Attended not screened",
                 "ATTENDED_NOT_SCREENED",
                 False,
+                False,
+            ),
+            (
+                AppointmentStatus.SCREENED,
+                "nhsuk-tag--green app-nowrap",
+                "Screened",
+                "SCREENED",
+                False,
+                True,
             ),
         ],
     )
@@ -62,6 +73,7 @@ class TestAppointmentPresenter:
         expected_text,
         expected_key,
         expected_is_confirmed,
+        expected_is_screened,
     ):
         mock_appointment.current_status = AppointmentStatus(state=status)
 
@@ -71,6 +83,7 @@ class TestAppointmentPresenter:
         assert result["text"] == expected_text
         assert result["key"] == expected_key
         assert result["is_confirmed"] == expected_is_confirmed
+        assert result["is_screened"] == expected_is_screened
 
     def test_clinic_url(self, mock_appointment):
         mock_appointment.clinic_slot.clinic.pk = "ef742f9d-76fb-47f1-8292-f7dcf456fc71"

--- a/manage_breast_screening/mammograms/tests/test_presenters.py
+++ b/manage_breast_screening/mammograms/tests/test_presenters.py
@@ -72,6 +72,13 @@ class TestAppointmentPresenter:
         assert result["key"] == expected_key
         assert result["is_confirmed"] == expected_is_confirmed
 
+    def test_clinic_url(self, mock_appointment):
+        mock_appointment.clinic_slot.clinic.pk = "ef742f9d-76fb-47f1-8292-f7dcf456fc71"
+        assert (
+            AppointmentPresenter(mock_appointment).clinic_url
+            == "/clinics/ef742f9d-76fb-47f1-8292-f7dcf456fc71/"
+        )
+
     def test_participant_url(self, mock_appointment):
         mock_appointment.screening_episode.participant.pk = UUID(
             "ac1b68ec-06a4-40a0-a016-7108dffe4397"
@@ -218,6 +225,13 @@ class TestClinicSlotPresenter:
         clinic_slot_mock.clinic.get_type_display.return_value = "Screening"
 
         assert ClinicSlotPresenter(clinic_slot_mock).clinic_type == "Screening"
+
+    def test_clinic_url(self, clinic_slot_mock):
+        clinic_slot_mock.clinic.pk = "ef742f9d-76fb-47f1-8292-f7dcf456fc71"
+        assert (
+            ClinicSlotPresenter(clinic_slot_mock).clinic_url
+            == "/clinics/ef742f9d-76fb-47f1-8292-f7dcf456fc71/"
+        )
 
     @time_machine.travel(datetime(2025, 5, 19, tzinfo=tz.utc))
     def test_slot_time_and_clinic_date(self, clinic_slot_mock):

--- a/manage_breast_screening/mammograms/tests/test_views.py
+++ b/manage_breast_screening/mammograms/tests/test_views.py
@@ -14,7 +14,7 @@ def appointment():
 class TestStartScreening:
     def test_appointment_continued(self, client, appointment):
         response = client.post(
-            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
             {"decision": "continue"},
         )
         assertRedirects(
@@ -27,7 +27,7 @@ class TestStartScreening:
 
     def test_appointment_stopped(self, client, appointment):
         response = client.post(
-            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
             {"decision": "dropout"},
         )
         assertRedirects(
@@ -40,7 +40,7 @@ class TestStartScreening:
 
     def test_renders_invalid_form(self, client, appointment):
         response = client.post(
-            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
             {},
         )
         assertContains(response, "There is a problem")
@@ -95,10 +95,9 @@ class TestAskForMedicalInformation:
 class TestCheckIn:
     def test_known_redirect(self, client, appointment):
         response = client.post(
-            reverse("mammograms:check_in", kwargs={"pk": appointment.pk}),
-            {"next": "start-screening"},
+            reverse("mammograms:check_in", kwargs={"pk": appointment.pk})
         )
         assertRedirects(
             response,
-            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
         )

--- a/manage_breast_screening/mammograms/tests/test_views.py
+++ b/manage_breast_screening/mammograms/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertRedirects
 
+from manage_breast_screening.participants.models import AppointmentStatus
 from manage_breast_screening.participants.tests.factories import AppointmentFactory
 
 
@@ -10,11 +11,39 @@ def appointment():
     return AppointmentFactory.create()
 
 
+@pytest.fixture
+def completed_appointment():
+    return AppointmentFactory.create(current_status=AppointmentStatus.SCREENED)
+
+
+@pytest.mark.django_db
+class TestShowAppointment:
+    def test_redirects_if_in_progress(self, client, appointment):
+        response = client.get(
+            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk})
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "mammograms:start_screening",
+                kwargs={"pk": appointment.pk},
+            ),
+        )
+
+    def test_renders_response(self, client, completed_appointment):
+        response = client.get(
+            reverse(
+                "mammograms:show_appointment", kwargs={"pk": completed_appointment.pk}
+            )
+        )
+        assert response.status_code == 200
+
+
 @pytest.mark.django_db
 class TestStartScreening:
     def test_appointment_continued(self, client, appointment):
         response = client.post(
-            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
             {"decision": "continue"},
         )
         assertRedirects(
@@ -27,7 +56,7 @@ class TestStartScreening:
 
     def test_appointment_stopped(self, client, appointment):
         response = client.post(
-            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
             {"decision": "dropout"},
         )
         assertRedirects(
@@ -38,9 +67,25 @@ class TestStartScreening:
             ),
         )
 
+    def test_already_completed_appointment_redirects(
+        self, client, completed_appointment
+    ):
+        response = client.get(
+            reverse(
+                "mammograms:start_screening", kwargs={"pk": completed_appointment.pk}
+            )
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "mammograms:show_appointment",
+                kwargs={"pk": completed_appointment.pk},
+            ),
+        )
+
     def test_renders_invalid_form(self, client, appointment):
         response = client.post(
-            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
             {},
         )
         assertContains(response, "There is a problem")
@@ -99,5 +144,5 @@ class TestCheckIn:
         )
         assertRedirects(
             response,
-            reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
+            reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
         )

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -12,8 +12,13 @@ urlpatterns = [
     ),
     path(
         "<uuid:pk>/",
-        views.StartScreening.as_view(),
+        views.ShowAppointment.as_view(),
         name="show_appointment",
+    ),
+    path(
+        "<uuid:pk>/start-screening/",
+        views.StartScreening.as_view(),
+        name="start_screening",
     ),
     path(
         "<uuid:pk>/ask-for-medical-information/",

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -27,12 +27,12 @@ urlpatterns = [
     ),
     path(
         "<uuid:pk>/awaiting-images/",
-        views.awaiting_images,
+        views.AwaitingImages.as_view(),
         name="awaiting_images",
     ),
     path(
         "<uuid:pk>/cannot-go-ahead/",
-        views.appointment_cannot_go_ahead,
+        views.AppointmentCannotGoAhead.as_view(),
         name="appointment_cannot_go_ahead",
     ),
 ]

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -11,9 +11,9 @@ urlpatterns = [
         name="check_in",
     ),
     path(
-        "<uuid:pk>/start-screening/",
+        "<uuid:pk>/",
         views.StartScreening.as_view(),
-        name="start_screening",
+        name="show_appointment",
     ),
     path(
         "<uuid:pk>/ask-for-medical-information/",

--- a/manage_breast_screening/mammograms/views.py
+++ b/manage_breast_screening/mammograms/views.py
@@ -204,4 +204,4 @@ def check_in(_request, pk):
     appointment = get_object_or_404(Appointment, pk=pk)
     appointment.statuses.create(state=AppointmentStatus.CHECKED_IN)
 
-    return redirect("mammograms:start_screening", pk=pk)
+    return redirect("mammograms:show_appointment", pk=pk)

--- a/manage_breast_screening/mammograms/views.py
+++ b/manage_breast_screening/mammograms/views.py
@@ -35,8 +35,8 @@ class BaseAppointmentForm(FormView):
 
     def get_appointment(self):
         return get_object_or_404(
-            Appointment.objects.prefetch_related(
-                "clinic_slot",
+            Appointment.objects.select_related(
+                "clinic_slot__clinic",
                 "screening_episode__participant",
                 "screening_episode__participant__address",
             ),

--- a/manage_breast_screening/participants/models.py
+++ b/manage_breast_screening/participants/models.py
@@ -317,6 +317,13 @@ class AppointmentStatus(models.Model):
     class Meta:
         ordering = ["-created_at"]
 
+    @property
+    def in_progress(self):
+        """
+        Is this state one of the in-progress states?
+        """
+        return self.state in [self.CONFIRMED, self.CHECKED_IN]
+
 
 class ParticipantReportedMammogram(BaseModel):
     class LocationType(models.TextChoices):

--- a/manage_breast_screening/participants/models.py
+++ b/manage_breast_screening/participants/models.py
@@ -228,10 +228,10 @@ class AppointmentQuerySet(models.QuerySet):
         )
 
     def upcoming(self):
-        return self.filter(clinic_slot__starts_at__gte=date.today())
+        return self.filter(clinic_slot__starts_at__date__gte=date.today())
 
     def past(self):
-        return self.filter(clinic_slot__starts_at__lt=date.today())
+        return self.filter(clinic_slot__starts_at__date__lt=date.today())
 
     def for_clinic_and_filter(self, clinic, filter):
         match filter:

--- a/manage_breast_screening/participants/presenters.py
+++ b/manage_breast_screening/participants/presenters.py
@@ -128,7 +128,7 @@ class ParticipantAppointmentsPresenter:
             clinic_type=clinic.get_type_display().capitalize(),
             setting_name=sentence_case(setting.name),
             status=self._present_status(appointment),
-            url=reverse("mammograms:start_screening", kwargs={"pk": appointment.pk}),
+            url=reverse("mammograms:show_appointment", kwargs={"pk": appointment.pk}),
         )
 
     def _present_status(self, appointment):

--- a/manage_breast_screening/participants/tests/system/test_ethnicity_details_form.py
+++ b/manage_breast_screening/participants/tests/system/test_ethnicity_details_form.py
@@ -72,7 +72,7 @@ class TestEthnicityDetailsForm(SystemTestCase):
         self.page.goto(
             self.live_server_url
             + reverse(
-                "mammograms:start_screening",
+                "mammograms:show_appointment",
                 kwargs={"pk": self.appointment.pk},
             )
         )
@@ -109,7 +109,7 @@ class TestEthnicityDetailsForm(SystemTestCase):
         expect(self.page).to_have_url(
             re.compile(
                 reverse(
-                    "mammograms:start_screening",
+                    "mammograms:show_appointment",
                     kwargs={"pk": self.appointment.pk},
                 )
             )

--- a/manage_breast_screening/participants/tests/system/test_participant_record.py
+++ b/manage_breast_screening/participants/tests/system/test_participant_record.py
@@ -81,7 +81,7 @@ class TestParticipantRecord(SystemTestCase):
         self.page.goto(
             self.live_server_url
             + reverse(
-                "mammograms:start_screening",
+                "mammograms:show_appointment",
                 kwargs={"pk": self.upcoming_appointment.pk},
             )
         )
@@ -117,7 +117,7 @@ class TestParticipantRecord(SystemTestCase):
 
     def then_i_should_be_back_on_the_appointment(self):
         path = reverse(
-            "mammograms:start_screening",
+            "mammograms:show_appointment",
             kwargs={"pk": self.upcoming_appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))
@@ -148,14 +148,14 @@ class TestParticipantRecord(SystemTestCase):
 
     def then_i_should_be_on_the_past_appointment_page(self):
         path = reverse(
-            "mammograms:start_screening",
+            "mammograms:show_appointment",
             kwargs={"pk": self.past_appointments[0].pk},
         )
         expect(self.page).to_have_url(re.compile(path))
 
     def then_i_should_be_on_the_upcoming_appointment_page(self):
         path = reverse(
-            "mammograms:start_screening",
+            "mammograms:show_appointment",
             kwargs={"pk": self.upcoming_appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))

--- a/manage_breast_screening/participants/tests/test_models.py
+++ b/manage_breast_screening/participants/tests/test_models.py
@@ -11,7 +11,7 @@ from manage_breast_screening.clinics.tests.factories import (
 )
 
 from .. import models
-from ..models import Ethnicity
+from ..models import AppointmentStatus, Ethnicity
 from .factories import AppointmentFactory, ParticipantFactory, ScreeningEpisodeFactory
 
 
@@ -239,3 +239,15 @@ def test_appointment_current_status():
 
     assert appointment.statuses.first().state == models.AppointmentStatus.CHECKED_IN
     assert appointment.current_status.state == models.AppointmentStatus.CHECKED_IN
+
+
+def test_appointment_status_in_progress():
+    assert AppointmentStatus(state=AppointmentStatus.CONFIRMED).in_progress
+    assert AppointmentStatus(state=AppointmentStatus.CHECKED_IN).in_progress
+    assert not AppointmentStatus(state=AppointmentStatus.CANCELLED).in_progress
+    assert not AppointmentStatus(state=AppointmentStatus.DID_NOT_ATTEND).in_progress
+    assert not AppointmentStatus(
+        state=AppointmentStatus.ATTENDED_NOT_SCREENED
+    ).in_progress
+    assert not AppointmentStatus(state=AppointmentStatus.PARTIALLY_SCREENED).in_progress
+    assert not AppointmentStatus(state=AppointmentStatus.SCREENED).in_progress

--- a/manage_breast_screening/participants/tests/test_models.py
+++ b/manage_breast_screening/participants/tests/test_models.py
@@ -122,13 +122,19 @@ class TestAppointment:
         time_machine.move_to(datetime(2025, 1, 1, 10, tzinfo=tz.utc))
 
         # > 00:00 so counts as upcoming still
-        earlier_today = AppointmentFactory.create(starts_at=datetime(2025, 1, 1, 9))
+        earlier_today = AppointmentFactory.create(
+            starts_at=datetime(2025, 1, 1, 9, tzinfo=tz.utc)
+        )
 
         # past
-        yesterday = AppointmentFactory.create(starts_at=datetime(2024, 12, 31, 9))
+        yesterday = AppointmentFactory.create(
+            starts_at=datetime(2024, 12, 31, 9, tzinfo=tz.utc)
+        )
 
         # upcoming
-        tomorrow = AppointmentFactory.create(starts_at=datetime(2025, 1, 2, 9))
+        tomorrow = AppointmentFactory.create(
+            starts_at=datetime(2025, 1, 2, 9, tzinfo=tz.utc)
+        )
 
         assertQuerySetEqual(
             models.Appointment.objects.past(), [yesterday], ordered=False

--- a/manage_breast_screening/participants/tests/test_presenters.py
+++ b/manage_breast_screening/participants/tests/test_presenters.py
@@ -154,7 +154,7 @@ class TestParticipantAppointmentPresenter:
                     "key": "CONFIRMED",
                     "text": "Confirmed",
                 },
-                "/mammograms/e3d475a6-c405-44d6-bbd7-bcb5cd4d4996/start-screening/",
+                "/mammograms/e3d475a6-c405-44d6-bbd7-bcb5cd4d4996/",
             )
         ]
 
@@ -175,7 +175,7 @@ class TestParticipantAppointmentPresenter:
                     "key": "PARTIALLY_SCREENED",
                     "text": "Partially screened",
                 },
-                "/mammograms/e76163c8-a594-4991-890d-a02097c67a2f/start-screening/",
+                "/mammograms/e76163c8-a594-4991-890d-a02097c67a2f/",
             ),
             ParticipantAppointmentsPresenter.PresentedAppointment(
                 "1 January 2019",
@@ -186,6 +186,6 @@ class TestParticipantAppointmentPresenter:
                     "key": "SCREENED",
                     "text": "Screened",
                 },
-                "/mammograms/6473a629-e7c4-43ca-87f3-ab9526aab07c/start-screening/",
+                "/mammograms/6473a629-e7c4-43ca-87f3-ab9526aab07c/",
             ),
         ]

--- a/manage_breast_screening/participants/tests/test_views.py
+++ b/manage_breast_screening/participants/tests/test_views.py
@@ -1,6 +1,5 @@
 import pytest
 from django.urls import reverse
-from pytest_django.asserts import assertTemplateUsed
 
 from manage_breast_screening.participants.tests.factories import ParticipantFactory
 
@@ -12,9 +11,8 @@ def participant():
 
 @pytest.mark.django_db
 class TestShowParticipant:
-    def test_renders_template(self, client, participant):
+    def test_renders_response(self, client, participant):
         response = client.get(
             reverse("participants:show", kwargs={"pk": participant.pk}),
         )
         assert response.status_code == 200
-        assertTemplateUsed("participants/show.jinja")


### PR DESCRIPTION
## Description
<img width="1527" height="1252" alt="Screenshot of a completed appointment, showing the appointment details" src="https://github.com/user-attachments/assets/434986ad-8530-4272-ba02-ae6c0d0b78c0" />

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9812

## Review notes
I've followed Malcolm's suggestion of having two separate views, with the show view redirecting to the start screening view if the appointment is in progress (currently equivalent to being in either the "confirmed" or "checked in" states; there is no special logic to actually require the check in). See ticket for more details.

The templates are completely separate, but share common components.

Currently the appointment page is `/mammograms/{id}/` and the other pages are `/mammograms/{id}/{step}`. Perhaps we could rename this from `mammograms` to `appointments`?