### PR TITLE
feat: add proper titles to each page

### DIFF
--- a/manage_breast_screening/clinics/jinja2/clinics/show.jinja
+++ b/manage_breast_screening/clinics/jinja2/clinics/show.jinja
@@ -17,7 +17,7 @@
 {% block page_content %}
   <h1 class="nhsuk-heading-l app-header">
       <span class="nhsuk-caption-l">{{ presented_clinic.setting_name }}</span>
-      {{ presented_clinic.risk_type }} screening clinic
+      {{ presented_clinic.heading }}
 
       <div class="app-header__status-tag">
         {{ tag({

--- a/manage_breast_screening/clinics/presenters.py
+++ b/manage_breast_screening/clinics/presenters.py
@@ -59,6 +59,10 @@ class ClinicPresenter:
     def setting_name(self):
         return self._clinic.setting.name
 
+    @cached_property
+    def heading(self):
+        return f"{self.risk_type} screening clinic"
+
 
 class AppointmentListPresenter:
     def __init__(self, clinic_pk, appointments, filter, counts_by_filter):

--- a/manage_breast_screening/clinics/views.py
+++ b/manage_breast_screening/clinics/views.py
@@ -13,7 +13,7 @@ def clinic_list(request, filter="today"):
     return render(
         request,
         "clinics/index.jinja",
-        context={"presenter": presenter},
+        context={"presenter": presenter, "page_title": presenter.heading},
     )
 
 
@@ -36,6 +36,7 @@ def clinic(request, pk, filter="remaining"):
         context={
             "presented_clinic": presented_clinic,
             "presented_appointment_list": presented_appointment_list,
+            "page_title": presented_clinic.heading,
         },
     )
 

--- a/manage_breast_screening/core/jinja2/layout-app.jinja
+++ b/manage_breast_screening/core/jinja2/layout-app.jinja
@@ -7,6 +7,8 @@
   <script type="module" src="{{ static('js/bundle.js' )}}"></script>
 {% endblock %}
 
+{% block pageTitle %}{% if form and form.errors %}Error: {% endif %}{% if page_title %}{{page_title}} - {% endif %}Manage breast screening - NHS{% endblock %}
+
 {% block header %}
   {{ header({
     "showNav": "true",

--- a/manage_breast_screening/core/jinja2/layout-app.jinja
+++ b/manage_breast_screening/core/jinja2/layout-app.jinja
@@ -7,7 +7,7 @@
   <script type="module" src="{{ static('js/bundle.js' )}}"></script>
 {% endblock %}
 
-{% block pageTitle %}{% if form and form.errors %}Error: {% endif %}{% if page_title %}{{page_title}} - {% endif %}Manage breast screening - NHS{% endblock %}
+{% block pageTitle %}{% if form and form.errors %}Error: {% endif %}{% if page_title %}{{page_title}} – {% endif %}Manage breast screening – NHS{% endblock %}
 
 {% block header %}
   {{ header({

--- a/manage_breast_screening/core/jinja2/wizard_step.jinja
+++ b/manage_breast_screening/core/jinja2/wizard_step.jinja
@@ -25,7 +25,7 @@
     {% if caption %}
       <span class="nhsuk-caption-l">{{ caption }}</span>
     {% endif %}
-    {{title}}
+    {{ heading }}
   </h1>
   {% endblock heading %}
 

--- a/manage_breast_screening/core/tests/jinja2/conftest.py
+++ b/manage_breast_screening/core/tests/jinja2/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from django.conf import settings
+from jinja2 import ChainableUndefined, Environment, FileSystemLoader
+
+from manage_breast_screening.config.jinja2_env import environment
+
+
+@pytest.fixture
+def jinja_env() -> Environment:
+    return environment(
+        loader=FileSystemLoader(settings.BASE_DIR / "core" / "jinja2"),
+        undefined=ChainableUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )

--- a/manage_breast_screening/core/tests/jinja2/test_base_template.py
+++ b/manage_breast_screening/core/tests/jinja2/test_base_template.py
@@ -12,10 +12,10 @@ form_with_errors.errors = {"field": ["mooo"]}
 @pytest.mark.parametrize(
     "page_title,form,expected_title",
     [
-        ("", None, "Manage breast screening - NHS"),
-        ("Page 1", None, "Page 1 - Manage breast screening - NHS"),
-        ("Page 2", form_with_errors, "Error: Page 2 - Manage breast screening - NHS"),
-        ("Page 3", form, "Page 3 - Manage breast screening - NHS"),
+        ("", None, "Manage breast screening – NHS"),
+        ("Page 1", None, "Page 1 – Manage breast screening – NHS"),
+        ("Page 2", form_with_errors, "Error: Page 2 – Manage breast screening – NHS"),
+        ("Page 3", form, "Page 3 – Manage breast screening – NHS"),
     ],
 )
 def test_page_title(jinja_env, page_title, form, expected_title):

--- a/manage_breast_screening/core/tests/jinja2/test_base_template.py
+++ b/manage_breast_screening/core/tests/jinja2/test_base_template.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.forms import Form
+
+form = MagicMock(autospec=Form)
+form.errors = {}
+form_with_errors = MagicMock(autospec=Form)
+form_with_errors.errors = {"field": ["mooo"]}
+
+
+@pytest.mark.parametrize(
+    "page_title,form,expected_title",
+    [
+        ("", None, "Manage breast screening - NHS"),
+        ("Page 1", None, "Page 1 - Manage breast screening - NHS"),
+        ("Page 2", form_with_errors, "Error: Page 2 - Manage breast screening - NHS"),
+        ("Page 3", form, "Page 3 - Manage breast screening - NHS"),
+    ],
+)
+def test_page_title(jinja_env, page_title, form, expected_title):
+    template = jinja_env.from_string(
+        """
+    {% extends "layout-app.jinja" %}
+    """
+    )
+    html = template.render({"page_title": page_title, "form": form})
+    assert f"<title>{expected_title}</title>" in html

--- a/manage_breast_screening/core/tests/jinja2/test_django_form_helpers.py
+++ b/manage_breast_screening/core/tests/jinja2/test_django_form_helpers.py
@@ -1,25 +1,10 @@
 from textwrap import dedent
 
-import pytest
-from django.conf import settings
 from django.forms import ChoiceField, Form
-from jinja2 import ChainableUndefined, Environment, FileSystemLoader
-
-from manage_breast_screening.config.jinja2_env import environment
 
 
 class ABForm(Form):
     ab_choice = ChoiceField(choices=(("a", "A"), ("b", "B")))
-
-
-@pytest.fixture
-def jinja_env() -> Environment:
-    return environment(
-        loader=FileSystemLoader(settings.BASE_DIR / "core" / "jinja2"),
-        undefined=ChainableUndefined,
-        trim_blocks=True,
-        lstrip_blocks=True,
-    )
 
 
 class TestDjangoFormHelpers:

--- a/manage_breast_screening/mammograms/jinja2/mammograms/show/appointment_details.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/show/appointment_details.jinja
@@ -23,7 +23,7 @@
       <span class="nhsuk-caption-l">
         {{ caption }}
       </span>
-      {{ title }}
+      {{ heading }}
     </h1>
 
     <div class="app-header__status-tag">

--- a/manage_breast_screening/mammograms/jinja2/mammograms/start_screening.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/start_screening.jinja
@@ -12,7 +12,7 @@
       <span class="nhsuk-caption-l">
         {{ caption }}
       </span>
-      {{ title }}
+      {{ heading }}
     </h1>
 
     <div class="app-header__status-tag">

--- a/manage_breast_screening/mammograms/presenters.py
+++ b/manage_breast_screening/mammograms/presenters.py
@@ -44,6 +44,10 @@ class AppointmentPresenter:
         return self.clinic_slot.clinic_url
 
     @cached_property
+    def caption(self):
+        return f"{self.clinic_slot.clinic_type} appointment"
+
+    @cached_property
     def start_time(self):
         return self.clinic_slot.starts_at
 

--- a/manage_breast_screening/mammograms/views.py
+++ b/manage_breast_screening/mammograms/views.py
@@ -92,7 +92,7 @@ class ShowAppointment(AppointmentMixin, View):
         )
 
         context = {
-            "title": appointment_presenter.participant.full_name,
+            "heading": appointment_presenter.participant.full_name,
             "caption": appointment_presenter.caption,
             "page_title": appointment_presenter.caption,
             "presented_appointment": appointment_presenter,
@@ -129,7 +129,7 @@ class StartScreening(InProgressAppointmentMixin, FormView):
 
         context.update(
             {
-                "title": appointment_presenter.participant.full_name,
+                "heading": appointment_presenter.participant.full_name,
                 "caption": appointment_presenter.caption,
                 "page_title": appointment_presenter.caption,
                 "presented_appointment": appointment_presenter,
@@ -170,7 +170,7 @@ class AskForMedicalInformation(InProgressAppointmentMixin, FormView):
             {
                 "participant": participant,
                 "caption": participant.full_name,
-                "title": "Medical information",
+                "heading": "Medical information",
                 "page_title": "Medical information",
                 "decision_legend": "Has the participant shared any relevant medical information?",
                 "cannot_continue_link": {
@@ -208,7 +208,7 @@ class RecordMedicalInformation(InProgressAppointmentMixin, FormView):
         )
         context.update(
             {
-                "title": "Record medical information",
+                "heading": "Record medical information",
                 "page_title": "Record medical information",
                 "participant": participant,
                 "caption": participant.full_name,
@@ -239,7 +239,7 @@ class AppointmentCannotGoAhead(InProgressAppointmentMixin, FormView):
         participant = self.appointment.screening_episode.participant
         context.update(
             {
-                "title": "Appointment cannot go ahead",
+                "heading": "Appointment cannot go ahead",
                 "caption": participant.full_name,
                 "page_title": "Appointment cannot go ahead",
                 "decision_legend": "Does the appointment need to be rescheduled?",
@@ -261,7 +261,7 @@ class AwaitingImages(InProgressAppointmentMixin, TemplateView):
     template_name = "mammograms/awaiting_images.jinja"
 
     def get_context_data(self, **kwargs):
-        return {"title": "Awaiting images", "page_title": "Awaiting images"}
+        return {"heading": "Awaiting images", "page_title": "Awaiting images"}
 
 
 @require_http_methods(["POST"])

--- a/manage_breast_screening/mammograms/views.py
+++ b/manage_breast_screening/mammograms/views.py
@@ -93,7 +93,8 @@ class ShowAppointment(AppointmentMixin, View):
 
         context = {
             "title": appointment_presenter.participant.full_name,
-            "caption": f"{appointment_presenter.clinic_slot.clinic_type} appointment",
+            "caption": appointment_presenter.caption,
+            "page_title": appointment_presenter.caption,
             "presented_appointment": appointment_presenter,
             "presented_participant": appointment_presenter.participant,
             "presented_mammograms": last_known_mammogram_presenter,
@@ -129,7 +130,8 @@ class StartScreening(InProgressAppointmentMixin, FormView):
         context.update(
             {
                 "title": appointment_presenter.participant.full_name,
-                "caption": f"{appointment_presenter.clinic_slot.clinic_type} appointment",
+                "caption": appointment_presenter.caption,
+                "page_title": appointment_presenter.caption,
                 "presented_appointment": appointment_presenter,
                 "presented_participant": appointment_presenter.participant,
                 "presented_mammograms": last_known_mammogram_presenter,
@@ -169,6 +171,7 @@ class AskForMedicalInformation(InProgressAppointmentMixin, FormView):
                 "participant": participant,
                 "caption": participant.full_name,
                 "title": "Medical information",
+                "page_title": "Medical information",
                 "decision_legend": "Has the participant shared any relevant medical information?",
                 "cannot_continue_link": {
                     "href": reverse(
@@ -206,6 +209,7 @@ class RecordMedicalInformation(InProgressAppointmentMixin, FormView):
         context.update(
             {
                 "title": "Record medical information",
+                "page_title": "Record medical information",
                 "participant": participant,
                 "caption": participant.full_name,
                 "decision_legend": "Can imaging go ahead?",
@@ -237,6 +241,7 @@ class AppointmentCannotGoAhead(InProgressAppointmentMixin, FormView):
             {
                 "title": "Appointment cannot go ahead",
                 "caption": participant.full_name,
+                "page_title": "Appointment cannot go ahead",
                 "decision_legend": "Does the appointment need to be rescheduled?",
             }
         )
@@ -256,7 +261,7 @@ class AwaitingImages(InProgressAppointmentMixin, TemplateView):
     template_name = "mammograms/awaiting_images.jinja"
 
     def get_context_data(self, **kwargs):
-        return {"title": "Awaiting images"}
+        return {"title": "Awaiting images", "page_title": "Awaiting images"}
 
 
 @require_http_methods(["POST"])

--- a/manage_breast_screening/participants/views.py
+++ b/manage_breast_screening/participants/views.py
@@ -52,6 +52,7 @@ def show(request, pk):
             "presented_participant": presented_participant,
             "presented_appointments": presented_appointments,
             "heading": participant.full_name,
+            "page_title": "Participant",
             "back_link": {
                 "text": "Back to participants",
                 "href": reverse("participants:index"),
@@ -88,6 +89,7 @@ def edit_ethnicity(request, pk):
                 "text": "Go back",
                 "href": return_url,
             },
+            "page_title": "Ethnicity",
         },
     )
 
@@ -120,6 +122,7 @@ def add_previous_mammogram(request, pk):
         {
             "title": "Add details of a previous mammogram",
             "caption": participant.full_name,
+            "page_title": "Add details of a previous mammogram",
             "form": form,
             "back_link_params": {"href": return_url, "text": "Go back"},
             "return_url": return_url,


### PR DESCRIPTION
## Description
While working on my ticket I noticed we never set the titles to anything other than "NHS".

This PR adds in titles, following the general pattern of "{heading} - Manage breast screening - NHS"

Except sometimes the caption is used instead of the heading, to avoid PII in page titles.

If an error is on the page, prefix with "Error: ". This is done automatically in the base template, as long as the form object is named "form".

## Review notes
I've defined `page_title` - the part of the title that is unique to the page - in the view context. It could also go in the template itself, but currently we are defining other headings in the view so thought it made sense for these values to live together.