### PR TITLE
[DTOSS-9814] mark special appointment reasons as temporary

### DIFF
--- a/manage_breast_screening/core/jinja2/django_form_helpers.jinja
+++ b/manage_breast_screening/core/jinja2/django_form_helpers.jinja
@@ -22,7 +22,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro _render(form_attribute, legend=None, hint=None, component=radios) %}
+{% macro app_radios(form_attribute, legend=None, hint=None) %}
   {% if form_attribute.errors %}
     {% set error_message = {"text": form_attribute.errors | first} %}
   {% endif %}
@@ -36,7 +36,7 @@
       "checked": form_attribute.value() == choice[0]
     }] %}
   {% endfor %}
-  {{ component({
+  {{ radios_component({
     "name": form_attribute.html_name,
     "idPrefix": form_attribute.auto_id,
     "fieldset":  {
@@ -54,12 +54,36 @@
   }) }}
 {% endmacro %}
 
-{% macro app_radios(form_attribute, legend=None, hint=None) %}
-  {{ _render(form_attribute=form_attribute, legend=legend, hint=hint, component=radios_component) }}
-{% endmacro %}
-
 {% macro app_checkboxes(form_attribute, legend=None, hint=None) %}
-  {{ _render(form_attribute=form_attribute, legend=legend, hint=hint, component=checkboxes_component) }}
+  {% if form_attribute.errors %}
+    {% set error_message = {"text": form_attribute.errors | first} %}
+  {% endif %}
+  {% set ns = namespace(items=[]) %}
+  {% set choice_field = form_attribute.field %}
+  {% for choice in choice_field.choices %}
+    {% set ns.items = ns.items + [{
+      "id": form_attribute.auto_id if loop.first,
+      "value": choice[0],
+      "text": choice[1],
+      "checked": choice[0] in (form_attribute.value() or [])
+    }] %}
+  {% endfor %}
+  {{ checkboxes_component({
+    "name": form_attribute.html_name,
+    "idPrefix": form_attribute.auto_id,
+    "fieldset":  {
+      "legend": {
+        "text": legend,
+        "classes": "nhsuk-fieldset__legend--m",
+        "isPageHeading": false
+      }
+    } if legend,
+    "errorMessage": error_message,
+    "hint": {
+      "html": hint|e
+    } if hint,
+    "items": ns.items
+  }) }}
 {% endmacro %}
 
 {% macro app_select(form_attribute, label=None, hint=None) %}

--- a/manage_breast_screening/core/jinja2/layout-form.jinja
+++ b/manage_breast_screening/core/jinja2/layout-form.jinja
@@ -1,0 +1,36 @@
+{% extends 'layout-app.jinja' %}
+{% from 'back-link/macro.jinja' import backLink %}
+{% from 'django_form_helpers.jinja' import form_error_summary %}
+
+{% block beforeContent %}
+  {% if back_link_params %}
+  {{ backLink(back_link_params) }}
+  {% endif %}
+{% endblock beforeContent %}
+
+{% block messages %}
+  {{ form_error_summary(form) }}
+{% endblock %}
+
+{% block page_content %}
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <h1 class="nhsuk-heading-l">
+      {% if caption %}
+      <span class="nhsuk-caption-l">
+        {{ caption }}
+      </span>
+      {% endif %}
+      {{ heading }}
+    </h1>
+
+    <form action="{{request.path}}" method="POST" novalidate>
+      {{ csrf_input }}
+
+      {% block form %}
+      {% endblock %}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/manage_breast_screening/mammograms/forms/__init__.py
+++ b/manage_breast_screening/mammograms/forms/__init__.py
@@ -2,7 +2,10 @@ from .appointment_cannot_go_ahead_form import AppointmentCannotGoAheadForm
 from .ask_for_medical_information_form import AskForMedicalInformationForm
 from .record_medical_information_form import RecordMedicalInformationForm
 from .screening_appointment_form import ScreeningAppointmentForm
-from .special_appointment_forms import ProvideSpecialAppointmentDetailsForm
+from .special_appointment_forms import (
+    MarkReasonsTemporaryForm,
+    ProvideSpecialAppointmentDetailsForm,
+)
 
 __all__ = [
     "AppointmentCannotGoAheadForm",
@@ -10,4 +13,5 @@ __all__ = [
     "RecordMedicalInformationForm",
     "ScreeningAppointmentForm",
     "ProvideSpecialAppointmentDetailsForm",
+    "MarkReasonsTemporaryForm",
 ]

--- a/manage_breast_screening/mammograms/forms/special_appointment_forms.py
+++ b/manage_breast_screening/mammograms/forms/special_appointment_forms.py
@@ -75,27 +75,17 @@ class ProvideSpecialAppointmentDetailsForm(forms.Form):
             self.cleaned_data.get("any_temporary") == self.TemporaryChoices.YES
         )
 
-        # TODO: this can be simplified to just iterate
-        for reason in self.SupportReasons:
-            if reason.value in self.cleaned_data.get("support_reasons", []):
-                need = {
-                    "details": self.cleaned_data.get(
-                        reason.value.lower() + "_details", ""
-                    )
-                }
-                if not any_temporary:
-                    need["temporary"] = False
-                else:
-                    # TODO save a click where only a single reason is selected
+        for reason in self.cleaned_data.get("support_reasons", []):
+            need = {"details": self.cleaned_data.get(reason.lower() + "_details", "")}
+            if not any_temporary:
+                need["temporary"] = False
+            else:
+                # Preserve answers from the second form if we are editing the first form
+                existing_value = self.saved_data.get(reason, {}).get("temporary")
+                if existing_value is not None:
+                    need["temporary"] = existing_value
 
-                    # Preserve answers from the second form if we are editing the first form
-                    existing_value = self.saved_data.get(reason.value, {}).get(
-                        "temporary"
-                    )
-                    if existing_value is not None:
-                        need["temporary"] = existing_value
-
-                result[reason.value] = need
+            result[reason] = need
         return result
 
     def _init_from_json(self, json):

--- a/manage_breast_screening/mammograms/forms/special_appointment_forms.py
+++ b/manage_breast_screening/mammograms/forms/special_appointment_forms.py
@@ -27,11 +27,12 @@ class ProvideSpecialAppointmentDetailsForm(forms.Form):
     }
 
     def __init__(self, *args, **kwargs):
-        saved_data = kwargs.pop("saved_data", {})
+        self.saved_data = kwargs.pop("saved_data", {}) or {}
+
         super().__init__(*args, **kwargs)
 
         # Populate the initial data based on the JSON field
-        self._init_from_json(saved_data)
+        self._init_from_json(self.saved_data)
 
         # Allow all reasons to be unselected if editing, rather than creating
         # a special appointment.
@@ -73,6 +74,8 @@ class ProvideSpecialAppointmentDetailsForm(forms.Form):
         any_temporary = (
             self.cleaned_data.get("any_temporary") == self.TemporaryChoices.YES
         )
+
+        # TODO: this can be simplified to just iterate
         for reason in self.SupportReasons:
             if reason.value in self.cleaned_data.get("support_reasons", []):
                 need = {
@@ -82,6 +85,16 @@ class ProvideSpecialAppointmentDetailsForm(forms.Form):
                 }
                 if not any_temporary:
                     need["temporary"] = False
+                else:
+                    # TODO save a click where only a single reason is selected
+
+                    # Preserve answers from the second form if we are editing the first form
+                    existing_value = self.saved_data.get(reason.value, {}).get(
+                        "temporary"
+                    )
+                    if existing_value is not None:
+                        need["temporary"] = existing_value
+
                 result[reason.value] = need
         return result
 
@@ -100,8 +113,55 @@ class ProvideSpecialAppointmentDetailsForm(forms.Form):
                 initial[reason.value.lower() + "_details"] = need["details"]
 
         if any(need.get("temporary") for need in json.values()):
-            initial["any_temporary"] = self.TemporaryChoices.YES
+            initial["any_temporary"] = self.TemporaryChoices.YES  # type: ignore
         else:
-            initial["any_temporary"] = self.TemporaryChoices.NO
+            initial["any_temporary"] = self.TemporaryChoices.NO  # type: ignore
 
         self.initial = initial
+
+
+class MarkReasonsTemporaryForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        self.saved_data = kwargs.pop("saved_data", {}) or {}
+        super().__init__(*args, **kwargs)
+
+        choices = [
+            (reason.value, reason.label)
+            for reason in ProvideSpecialAppointmentDetailsForm.SupportReasons
+            if reason.value in self.saved_data
+        ]
+
+        self.fields["which_are_temporary"] = forms.MultipleChoiceField(
+            choices=choices,  # type: ignore
+            required=True,
+            error_messages={"required": "Select which reasons are temporary"},
+        )
+
+        # Populate the initial data based on the JSON field
+        self._init_from_json(self.saved_data)
+
+    def to_json(self):
+        """
+        Generate JSON that can be stored on the participant record
+        """
+        result = self.saved_data
+        for reason, details in self.saved_data.items():
+            temporary = reason in self.cleaned_data.get("which_are_temporary", [])
+            details["temporary"] = temporary
+
+        return result
+
+    def _init_from_json(self, json):
+        """
+        Set initial values from JSON stored on the participant record
+        """
+        if not json:
+            return
+
+        self.initial = {
+            "which_are_temporary": [
+                reason
+                for reason, details in self.saved_data.items()
+                if details and details.get("temporary", False)
+            ]
+        }

--- a/manage_breast_screening/mammograms/jinja2/mammograms/special_appointments/mark_reasons_temporary.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/special_appointments/mark_reasons_temporary.jinja
@@ -1,0 +1,12 @@
+{% extends 'layout-form.jinja' %}
+{% from 'django_form_helpers.jinja' import app_checkboxes %}
+{% from 'button/macro.jinja' import button %}
+
+{% block form %}
+    {{ app_checkboxes(form_attribute=form.which_are_temporary, legend="Which of these reasons are temporary?", hint="If any reasons are relevant to this appointment only, mark them as temporary so they are not retained the next time this participant is invited for breast screening") }}
+    <div class="nhsuk-button-group">
+      {{ button({
+        "text": "Continue"
+      }) }}
+    </div>
+{% endblock %}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/special_appointments/provide_special_appointment_details.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/special_appointments/provide_special_appointment_details.jinja
@@ -1,103 +1,78 @@
-{% extends 'layout-app.jinja' %}
-{% from 'warning-callout/macro.jinja' import warningCallout %}
+{% extends 'layout-form.jinja' %}
 {% from 'checkboxes/macro.jinja' import checkboxes %}
 {% from 'textarea/macro.jinja' import textarea %}
 {% from 'back-link/macro.jinja' import backLink %}
 {% from 'button/macro.jinja' import button %}
-{% from 'django_form_helpers.jinja' import app_radios, form_error_summary %}
+{% from 'django_form_helpers.jinja' import app_radios %}
 
-{% block beforeContent %}
-  {{ backLink(back_link_params) }}
-{% endblock beforeContent %}
-
-{% block messages %}
-  {{ form_error_summary(form) }}
-{% endblock %}
-
-{% block page_content %}
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-
-    <h1 class="nhsuk-heading-l">
-      <span class="nhsuk-caption-l">
-        {{ caption }}
-      </span>
-      {{ heading }}
-    </h1>
-
-    {% macro details_textarea(form, support_reasons_value) %}
-      {% set details_field_name = support_reasons_value.lower() + "_details" %}
-      {% set details_field = form[details_field_name] %}
-      {% set details_field_id = details_field.auto_id %}
-      {% set details_field_value = details_field.value() %}
-      {% set textarea_params = {
-        "label": {
-          "text": "Describe support required"
-        },
-        "id": details_field_id,
-        "name": details_field_name,
-        "value": details_field_value,
-        "hint": {
-          "text": hint
-        } if hint
+{% block form %}
+  {% macro details_textarea(form, support_reasons_value) %}
+    {% set details_field_name = support_reasons_value.lower() + "_details" %}
+    {% set details_field = form[details_field_name] %}
+    {% set details_field_id = details_field.auto_id %}
+    {% set details_field_value = details_field.value() %}
+    {% set textarea_params = {
+      "label": {
+        "text": "Describe support required"
+      },
+      "id": details_field_id,
+      "name": details_field_name,
+      "value": details_field_value,
+      "hint": {
+        "text": hint
+      } if hint
+    } %}
+    {% if details_field.errors %}
+      {% set error_params = {
+        "errorMessage": {
+          "text": form[details_field_name].errors | first
+        }
       } %}
-      {% if details_field.errors %}
-        {% set error_params = {
-          "errorMessage": {
-            "text": form[details_field_name].errors | first
+      {% set textarea_params = dict(textarea_params, **error_params) %}
+    {% endif %}
+    {{ textarea(textarea_params) }}
+  {% endmacro %}
+
+    {% set checkbox_items = [] %}
+
+    {% for value, label in form.support_reasons.field.choices %}
+        {% set hint = form.SupportReasonHints[value] %}
+
+        {% do checkbox_items.append({
+          "text": label,
+          "id": form.support_reasons.auto_id if loop.first,
+          "value": value,
+          "checked": value in (form.support_reasons.value() or []),
+          "conditional": {
+            "html": details_textarea(form=form, support_reasons_value=value)
           }
-        } %}
-        {% set textarea_params = dict(textarea_params, **error_params) %}
-      {% endif %}
-      {{ textarea(textarea_params) }}
-    {% endmacro %}
+        }) %}
+    {% endfor %}
 
-    <form action="{{request.path}}" method="POST" novalidate>
-      {% set checkbox_items = [] %}
+    {% if form.support_reasons.errors %}
+      {% set error_message = {"text": form.support_reasons.errors | first} %}
+    {% endif %}
 
-      {% for value, label in form.support_reasons.field.choices %}
-          {% set hint = form.SupportReasonHints[value] %}
+    {{ checkboxes({
+      "name": form.support_reasons.html_name,
+      "errorMessage": error_message,
+      "fieldset": {
+        "legend": {
+          "text": support_reasons_legend,
+          "classes": "nhsuk-fieldset__legend--m"
+        }
+      },
+      "hint": {
+        "text": "Select all that apply. When describing support required, include any special requests made by the participant or their carer."
+      },
+      "items": checkbox_items
+    }) }}
 
-          {% do checkbox_items.append({
-            "text": label,
-            "id": form.support_reasons.auto_id if loop.first,
-            "value": value,
-            "checked": value in (form.support_reasons.value() or []),
-            "conditional": {
-              "html": details_textarea(form=form, support_reasons_value=value)
-            }
-          }) %}
-      {% endfor %}
+    {{ app_radios(form_attribute=form.any_temporary, legend="Are any of these reasons temporary?", hint="This includes issues that are likely to be resolved by their next mammogram, for example a broken foot or a short-term eye problem.") }}
 
-      {% if form.support_reasons.errors %}
-        {% set error_message = {"text": form.support_reasons.errors | first} %}
-      {% endif %}
-
-      {{ checkboxes({
-        "name": form.support_reasons.html_name,
-        "errorMessage": error_message,
-        "fieldset": {
-          "legend": {
-            "text": support_reasons_legend,
-            "classes": "nhsuk-fieldset__legend--m"
-          }
-        },
-        "hint": {
-          "text": "Select all that apply. When describing support required, include any special requests made by the participant or their carer."
-        },
-        "items": checkbox_items
+    <div class="nhsuk-button-group">
+      {{ button({
+        "text": "Continue"
       }) }}
-
-      {{ app_radios(form_attribute=form.any_temporary, legend="Are any of these reasons temporary?", hint="This includes issues that are likely to be resolved by their next mammogram, for example a broken foot or a short-term eye problem.") }}
-
-      {{ csrf_input }}
-
-      <div class="nhsuk-button-group">
-        {{ button({
-          "text": "Continue"
-        }) }}
-      </div>
-    </form>
-  </div>
-</div>
+    </div>
 {% endblock %}

--- a/manage_breast_screening/mammograms/tests/system/test_editing_special_appointments.py
+++ b/manage_breast_screening/mammograms/tests/system/test_editing_special_appointments.py
@@ -22,25 +22,46 @@ class TestEditingSpecialAppointments(SystemTestCase):
     def test_setting_up_a_special_appointment(self):
         self.given_i_am_on_the_appointment_show_page()
         self.when_i_click_on_make_special_appointment()
-        self.and_i_add_a_need()
+        self.and_i_add_a_reason()
         self.and_i_select_no_reasons_are_temporary()
         self.and_i_submit_the_form()
         self.then_i_am_back_on_the_appointment()
         self.and_i_see_the_created_special_appointment()
 
-    def test_adding_extra_needs_to_a_special_appointment(self):
-        self.given_the_participant_already_has_extra_needs_set()
+    def test_setting_up_a_special_appointment_with_a_temporary_reason(self):
+        self.given_i_am_on_the_appointment_show_page()
+        self.when_i_click_on_make_special_appointment()
+        self.and_i_add_a_reason()
+        self.and_i_select_some_reasons_are_temporary()
+        self.and_i_submit_the_form()
+        self.then_i_am_back_on_the_appointment()
+        self.and_i_see_the_created_special_appointment()
+
+    def test_setting_up_a_special_appointment_with_multiple_reasons(self):
+        self.given_i_am_on_the_appointment_show_page()
+        self.when_i_click_on_make_special_appointment()
+        self.and_i_add_a_reason()
+        self.and_i_add_another_reason()
+        self.and_i_select_some_reasons_are_temporary()
+        self.and_i_submit_the_form()
+        self.then_i_select_the_temporary_reason()
+        self.and_i_submit_the_form()
+        self.then_i_am_back_on_the_appointment()
+        self.and_i_see_the_created_special_appointment_with_both_reasons()
+
+    def test_adding_reasons_to_a_special_appointment(self):
+        self.given_the_participant_already_has_reasons_set()
         self.and_i_am_on_the_appointment_show_page()
         self.then_i_see_the_special_appointment_banner()
 
         self.when_i_click_on_the_change_link()
-        self.and_i_add_a_need()
+        self.and_i_add_a_reason()
         self.and_i_submit_the_form()
         self.then_i_am_back_on_the_appointment()
         self.and_i_see_the_updated_special_appointment()
 
-    def test_removing_all_extra_needs_removes_the_banner(self):
-        self.given_the_participant_already_has_extra_needs_set()
+    def test_removing_all_reasons_removes_the_banner(self):
+        self.given_the_participant_already_has_reasons_set()
         self.and_i_am_on_the_appointment_show_page()
         self.when_i_click_on_the_change_link()
         self.and_i_remove_the_existing_need()
@@ -53,7 +74,7 @@ class TestEditingSpecialAppointments(SystemTestCase):
         self.when_i_submit_the_form()
         self.then_i_should_see_an_error_for_the_required_fields()
 
-    def given_the_participant_already_has_extra_needs_set(self):
+    def given_the_participant_already_has_reasons_set(self):
         self.participant.extra_needs = {
             "PHYSICAL_RESTRICTION": {
                 "details": "Uses wheelchair, needs accessible positioning and additional time for transfers"
@@ -93,7 +114,14 @@ class TestEditingSpecialAppointments(SystemTestCase):
         banner = self.page.locator(".nhsuk-warning-callout")
         expect(banner).to_be_visible()
         expect(banner).to_contain_text("Special appointment")
-        expect(banner).to_contain_text("Needs a BSL interpreter")
+        expect(banner).to_contain_text("Deaf in one ear")
+
+    def and_i_see_the_created_special_appointment_with_both_reasons(self):
+        banner = self.page.locator(".nhsuk-warning-callout")
+        expect(banner).to_be_visible()
+        expect(banner).to_contain_text("Special appointment")
+        expect(banner).to_contain_text("Deaf in one ear")
+        expect(banner).to_contain_text("Non-binary")
 
     def and_i_see_the_updated_special_appointment(self):
         banner = self.page.locator(".nhsuk-warning-callout")
@@ -102,7 +130,7 @@ class TestEditingSpecialAppointments(SystemTestCase):
         expect(banner).to_contain_text(
             "Uses wheelchair, needs accessible positioning and additional time for transfers"
         )
-        expect(banner).to_contain_text("Needs a BSL interpreter")
+        expect(banner).to_contain_text("Deaf in one ear")
 
     def and_i_do_not_see_the_special_appointment_banner(self):
         banner = self.page.locator(".nhsuk-warning-callout")
@@ -117,13 +145,21 @@ class TestEditingSpecialAppointments(SystemTestCase):
         banner = self.page.locator(".nhsuk-warning-callout")
         banner.get_by_text("Change").click()
 
-    def and_i_add_a_need(self):
+    def and_i_add_a_reason(self):
         self.page.get_by_label("Hearing").click()
         self.page.keyboard.press("Tab")
-        self.page.locator("*:focus").fill("Needs a BSL interpreter")
+        self.page.locator("*:focus").fill("Deaf in one ear")
+
+    def and_i_add_another_reason(self):
+        self.page.get_by_label("Gender identity").click()
+        self.page.keyboard.press("Tab")
+        self.page.locator("*:focus").fill("Non-binary")
 
     def and_i_select_no_reasons_are_temporary(self):
         self.page.get_by_label("No").click()
+
+    def and_i_select_some_reasons_are_temporary(self):
+        self.page.get_by_label("Yes").click()
 
     def and_i_submit_the_form(self):
         self.page.get_by_text("Continue").click()
@@ -148,3 +184,6 @@ class TestEditingSpecialAppointments(SystemTestCase):
 
     def when_i_click_on_make_special_appointment(self):
         self.page.get_by_text("Make special appointment").click()
+
+    def then_i_select_the_temporary_reason(self):
+        self.page.get_by_label("Hearing").click()

--- a/manage_breast_screening/mammograms/tests/views/test_special_appointments.py
+++ b/manage_breast_screening/mammograms/tests/views/test_special_appointments.py
@@ -10,7 +10,7 @@ from manage_breast_screening.mammograms.tests.forms.test_special_appointment_for
 
 @pytest.mark.django_db
 class TestSpecialAppointments:
-    def test_get_renders_a_response(self, client, appointment):
+    def test_get_provide_details_page_renders_a_response(self, client, appointment):
         response = client.get(
             reverse(
                 "mammograms:provide_special_appointment_details",
@@ -19,7 +19,18 @@ class TestSpecialAppointments:
         )
         assert response.status_code == 200
 
-    def test_valid_post_redirects_to_appointment(self, client, appointment):
+    def test_get_mark_temporary_page_renders_a_response(self, client, appointment):
+        response = client.get(
+            reverse(
+                "mammograms:mark_reasons_temporary",
+                kwargs={"pk": appointment.pk},
+            )
+        )
+        assert response.status_code == 200
+
+    def test_valid_post_redirects_to_appointment_if_no_temporary_reasons(
+        self, client, appointment
+    ):
         response = client.post(
             reverse(
                 "mammograms:provide_special_appointment_details",
@@ -39,10 +50,73 @@ class TestSpecialAppointments:
             ),
         )
 
-    def test_invalid_post_renders_response(self, client, appointment):
+    def test_valid_post_redirects_to_next_step_if_temporary_reasons(
+        self, client, appointment
+    ):
         response = client.post(
             reverse(
                 "mammograms:provide_special_appointment_details",
+                kwargs={"pk": appointment.pk},
+            ),
+            {
+                "support_reasons": [SupportReasons.MEDICAL_DEVICES],
+                "medical_devices_details": "has pacemaker",
+                "any_temporary": TemporaryChoices.YES,
+            },
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "mammograms:mark_reasons_temporary",
+                kwargs={"pk": appointment.pk},
+            ),
+        )
+
+    def test_valid_post_to_mark_temporary_redirects_to_appointment(
+        self, client, appointment
+    ):
+        participant = appointment.participant
+        participant.extra_needs = {
+            SupportReasons.MEDICAL_DEVICES: {"details": "abc"},
+            SupportReasons.HEARING: {"details": "abc"},
+        }
+        participant.save()
+
+        response = client.post(
+            reverse(
+                "mammograms:mark_reasons_temporary",
+                kwargs={"pk": appointment.pk},
+            ),
+            {
+                "which_are_temporary": [SupportReasons.MEDICAL_DEVICES],
+            },
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "mammograms:start_screening",
+                kwargs={"pk": appointment.pk},
+            ),
+        )
+
+    def test_invalid_post_to_provide_details_page_renders_response(
+        self, client, appointment
+    ):
+        response = client.post(
+            reverse(
+                "mammograms:provide_special_appointment_details",
+                kwargs={"pk": appointment.pk},
+            ),
+            {},
+        )
+        assert response.status_code == 200
+
+    def test_invalid_post_to_mark_temporary_page_renders_response(
+        self, client, appointment
+    ):
+        response = client.post(
+            reverse(
+                "mammograms:mark_reasons_temporary",
                 kwargs={"pk": appointment.pk},
             ),
             {},

--- a/manage_breast_screening/mammograms/tests/views/test_special_appointments.py
+++ b/manage_breast_screening/mammograms/tests/views/test_special_appointments.py
@@ -9,20 +9,11 @@ from manage_breast_screening.mammograms.tests.forms.test_special_appointment_for
 
 
 @pytest.mark.django_db
-class TestSpecialAppointments:
-    def test_get_provide_details_page_renders_a_response(self, client, appointment):
+class TestProvideDetails:
+    def test_get_renders_a_response(self, client, appointment):
         response = client.get(
             reverse(
                 "mammograms:provide_special_appointment_details",
-                kwargs={"pk": appointment.pk},
-            )
-        )
-        assert response.status_code == 200
-
-    def test_get_mark_temporary_page_renders_a_response(self, client, appointment):
-        response = client.get(
-            reverse(
-                "mammograms:mark_reasons_temporary",
                 kwargs={"pk": appointment.pk},
             )
         )
@@ -50,7 +41,7 @@ class TestSpecialAppointments:
             ),
         )
 
-    def test_valid_post_redirects_to_next_step_if_temporary_reasons(
+    def test_valid_post_redirects_to_appointment_if_one_temporary_reason(
         self, client, appointment
     ):
         response = client.post(
@@ -59,8 +50,34 @@ class TestSpecialAppointments:
                 kwargs={"pk": appointment.pk},
             ),
             {
-                "support_reasons": [SupportReasons.MEDICAL_DEVICES],
-                "medical_devices_details": "has pacemaker",
+                "support_reasons": [SupportReasons.LANGUAGE],
+                "language_details": "learning english",
+                "any_temporary": TemporaryChoices.YES,
+            },
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "mammograms:start_screening",
+                kwargs={"pk": appointment.pk},
+            ),
+        )
+
+    def test_valid_post_redirects_to_next_step_if_some_temporary_reasons(
+        self, client, appointment
+    ):
+        response = client.post(
+            reverse(
+                "mammograms:provide_special_appointment_details",
+                kwargs={"pk": appointment.pk},
+            ),
+            {
+                "support_reasons": [
+                    SupportReasons.PHYSICAL_RESTRICTION,
+                    SupportReasons.VISION,
+                ],
+                "physical_restriction_details": "broken leg",
+                "vision_details": "blind",
                 "any_temporary": TemporaryChoices.YES,
             },
         )
@@ -72,9 +89,31 @@ class TestSpecialAppointments:
             ),
         )
 
-    def test_valid_post_to_mark_temporary_redirects_to_appointment(
+    def test_invalid_post_to_provide_details_page_renders_response(
         self, client, appointment
     ):
+        response = client.post(
+            reverse(
+                "mammograms:provide_special_appointment_details",
+                kwargs={"pk": appointment.pk},
+            ),
+            {},
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestMarkTemporary:
+    def test_get_renders_a_response(self, client, appointment):
+        response = client.get(
+            reverse(
+                "mammograms:mark_reasons_temporary",
+                kwargs={"pk": appointment.pk},
+            )
+        )
+        assert response.status_code == 200
+
+    def test_valid_post_redirects_to_appointment(self, client, appointment):
         participant = appointment.participant
         participant.extra_needs = {
             SupportReasons.MEDICAL_DEVICES: {"details": "abc"},
@@ -99,26 +138,12 @@ class TestSpecialAppointments:
             ),
         )
 
-    def test_invalid_post_to_provide_details_page_renders_response(
-        self, client, appointment
-    ):
-        response = client.post(
-            reverse(
-                "mammograms:provide_special_appointment_details",
-                kwargs={"pk": appointment.pk},
-            ),
-            {},
-        )
-        assert response.status_code == 200
-
-    def test_invalid_post_to_mark_temporary_page_renders_response(
-        self, client, appointment
-    ):
+    def test_invalid_post_renders_response(self, client, appointment):
         response = client.post(
             reverse(
                 "mammograms:mark_reasons_temporary",
                 kwargs={"pk": appointment.pk},
             ),
-            {},
+            {"which_are_temporary": []},
         )
         assert response.status_code == 200

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -45,4 +45,9 @@ urlpatterns = [
         views.ProvideSpecialAppointmentDetails.as_view(),
         name="provide_special_appointment_details",
     ),
+    path(
+        "<uuid:pk>/special-appointment/which-reasons/",
+        views.MarkReasonsTemporary.as_view(),
+        name="mark_reasons_temporary",
+    ),
 ]

--- a/manage_breast_screening/mammograms/views/__init__.py
+++ b/manage_breast_screening/mammograms/views/__init__.py
@@ -7,7 +7,7 @@ from .appointment_flow import (
     StartScreening,
     check_in,
 )
-from .special_appointments import ProvideSpecialAppointmentDetails
+from .special_appointments import MarkReasonsTemporary, ProvideSpecialAppointmentDetails
 
 __all__ = [
     "check_in",
@@ -17,5 +17,6 @@ __all__ = [
     "AwaitingImages",
     "AppointmentCannotGoAhead",
     "ShowAppointment",
+    "MarkReasonsTemporary",
     "ProvideSpecialAppointmentDetails",
 ]

--- a/manage_breast_screening/mammograms/views/special_appointments.py
+++ b/manage_breast_screening/mammograms/views/special_appointments.py
@@ -4,7 +4,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import FormView
 
-from ..forms import ProvideSpecialAppointmentDetailsForm
+from ..forms import MarkReasonsTemporaryForm, ProvideSpecialAppointmentDetailsForm
 from .appointment_flow import AppointmentMixin
 
 
@@ -37,6 +37,57 @@ class ProvideSpecialAppointmentDetails(AppointmentMixin, FormView):
                 "caption": self.participant.full_name,
                 "heading": "Provide special appointment details",
                 "support_reasons_legend": f"Why does {self.participant.full_name} need additional support?",
+            },
+        )
+
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["saved_data"] = self.participant.extra_needs
+        return kwargs
+
+    def form_valid(self, form):
+        self.participant.extra_needs = form.to_json()
+        self.participant.save()
+
+        if (
+            form.cleaned_data["any_temporary"]
+            == ProvideSpecialAppointmentDetailsForm.TemporaryChoices.YES
+        ):
+            return redirect("mammograms:mark_reasons_temporary", pk=self.appointment_pk)
+        else:
+            return redirect("mammograms:start_screening", pk=self.appointment_pk)
+
+
+class MarkReasonsTemporary(AppointmentMixin, FormView):
+    """
+    The second form you see when editing/adding special appointment details,
+    if you select "yes" for "any of these reasons are temporary" on the first form.
+    The data for this is currently stored on a JSONField on the participant model.
+    """
+
+    form_class = MarkReasonsTemporaryForm
+    template_name = "mammograms/special_appointments/mark_reasons_temporary.jinja"
+
+    @cached_property
+    def participant(self):
+        return self.appointment.participant
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+
+        context.update(
+            {
+                "back_link_params": {
+                    "href": reverse(
+                        "mammograms:provide_special_appointment_details",
+                        kwargs={"pk": self.appointment_pk},
+                    ),
+                    "text": "Back",
+                },
+                "caption": self.participant.full_name,
+                "heading": "Which of these reasons are temporary?",
             },
         )
 

--- a/manage_breast_screening/mammograms/views/special_appointments.py
+++ b/manage_breast_screening/mammograms/views/special_appointments.py
@@ -48,12 +48,14 @@ class ProvideSpecialAppointmentDetails(AppointmentMixin, FormView):
         return kwargs
 
     def form_valid(self, form):
-        self.participant.extra_needs = form.to_json()
+        extra_needs = form.to_json()
+        self.participant.extra_needs = extra_needs
         self.participant.save()
 
         if (
             form.cleaned_data["any_temporary"]
             == ProvideSpecialAppointmentDetailsForm.TemporaryChoices.YES
+            and len(extra_needs.keys()) > 1
         ):
             return redirect("mammograms:mark_reasons_temporary", pk=self.appointment_pk)
         else:


### PR DESCRIPTION
## Description

This PR adds the secondary form, shown when you mark that some of the reasons are temporary when adding or changing a special appointment.

<img width="802" height="576" alt="Screenshot showing the new form" src="https://github.com/user-attachments/assets/3bdd0579-68ee-42ce-84f9-21f66fa5b790" />

Haven't updated the display to show this yet, that'll be a separate ticket.

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9814

## Review notes
We don't have proper models for this yet, I've kept it as a JSON field on participant. We can revisit this when we do the confirm page.