### PR TITLE
Add missing auditing to views (mammograms)

### DIFF
--- a/manage_breast_screening/conftest.py
+++ b/manage_breast_screening/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+
+@pytest.fixture
+def user():
+    return get_user_model().objects.create_user(username="user1", password="123")
+
+
+@pytest.fixture
+def logged_in_client(user, client):
+    client.force_login(user)
+    return client

--- a/manage_breast_screening/core/services/auditor.py
+++ b/manage_breast_screening/core/services/auditor.py
@@ -78,6 +78,9 @@ class Auditor:
             )
 
     def audit_create(self, object) -> AuditLog:
+        if object is None:
+            raise TypeError("object must not be None")
+
         return _log_action(
             object,
             operation=AuditLog.Operations.CREATE,
@@ -86,6 +89,9 @@ class Auditor:
         )
 
     def audit_update(self, object) -> AuditLog:
+        if object is None:
+            raise TypeError("object must not be None")
+
         return _log_action(
             object,
             operation=AuditLog.Operations.UPDATE,
@@ -94,6 +100,9 @@ class Auditor:
         )
 
     def audit_delete(self, object) -> AuditLog:
+        if object is None:
+            raise TypeError("object must not be None")
+
         if object.pk is None:
             raise AuditAfterDeleteError(
                 "Error auditing deletion of an unsaved object. Audit prior to deletion instead."

--- a/manage_breast_screening/core/services/auditor.py
+++ b/manage_breast_screening/core/services/auditor.py
@@ -72,10 +72,13 @@ class Auditor:
         self.actor = actor if actor and actor.is_authenticated else None
         self.system_update_id = system_update_id
 
-        if self.actor is None and self.system_update_id is None:
-            raise AnonymousAuditError(
-                "Attempted to audit an operation with no logged in user and no system_update_id"
-            )
+        # Temporarily disable the requirement for a logged in user until we've implemented auth.
+        # This should also consider non-production environments such as review apps.
+        #
+        # if self.actor is None and self.system_update_id is None:
+        #     raise AnonymousAuditError(
+        #         "Attempted to audit an operation with no logged in user and no system_update_id"
+        #     )
 
     def audit_create(self, object) -> AuditLog:
         if object is None:

--- a/manage_breast_screening/mammograms/views/special_appointments.py
+++ b/manage_breast_screening/mammograms/views/special_appointments.py
@@ -4,6 +4,8 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import FormView
 
+from manage_breast_screening.core.services.auditor import Auditor
+
 from ..forms import MarkReasonsTemporaryForm, ProvideSpecialAppointmentDetailsForm
 from .appointment_flow import AppointmentMixin
 
@@ -51,6 +53,7 @@ class ProvideSpecialAppointmentDetails(AppointmentMixin, FormView):
         extra_needs = form.to_json()
         self.participant.extra_needs = extra_needs
         self.participant.save()
+        Auditor.from_request(self.request).audit_update(self.participant)
 
         if (
             form.cleaned_data["any_temporary"]
@@ -103,5 +106,6 @@ class MarkReasonsTemporary(AppointmentMixin, FormView):
     def form_valid(self, form):
         self.participant.extra_needs = form.to_json()
         self.participant.save()
+        Auditor.from_request(self.request).audit_update(self.participant)
 
         return redirect("mammograms:start_screening", pk=self.appointment_pk)


### PR DESCRIPTION
## Description

## Jira link
This is not ticketed up but relates to the pre-mammogram discussion epic: https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8899

There are forms in the participants app that are still missing auditing but I think we can sort those out in a separate ticket.

## Review notes

I think the general rule we should be following is that anywhere we have a POST request, we should expect at least audit record to be created. If this is the case, we could check this using static analysis.