### PR TITLE
[DTOSS-10297] HTTP basic authentication

### DIFF
--- a/manage_breast_screening/config/settings.py
+++ b/manage_breast_screening/config/settings.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "manage_breast_screening.core.middleware.BasicAuthMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -227,3 +228,12 @@ LOGGING = {
 }
 
 AUDIT_EXCLUDED_FIELDS = ["password", "token", "created_at", "updated_at", "id"]
+
+BASIC_AUTH_USERNAME = environ.get("BASIC_AUTH_USERNAME")
+BASIC_AUTH_PASSWORD = environ.get("BASIC_AUTH_PASSWORD")
+BASIC_AUTH_REALM = ""
+BASIC_AUTH_ENABLED = (
+    boolean_env("BASIC_AUTH_ENABLED", default=False)
+    and BASIC_AUTH_USERNAME
+    and BASIC_AUTH_PASSWORD
+)

--- a/manage_breast_screening/conftest.py
+++ b/manage_breast_screening/conftest.py
@@ -1,5 +1,10 @@
+from unittest import TestCase
+
 import pytest
 from django.contrib.auth import get_user_model
+
+# Show long diffs in failed test output
+TestCase.maxDiff = None
 
 
 @pytest.fixture

--- a/manage_breast_screening/core/conftest.py
+++ b/manage_breast_screening/core/conftest.py
@@ -1,0 +1,16 @@
+from base64 import b64encode
+
+import pytest
+
+
+@pytest.fixture
+def set_basic_auth_credentials(settings, user):
+    settings.BASIC_AUTH_ENABLED = True
+    settings.BASIC_AUTH_USERNAME = "testusername"
+    settings.BASIC_AUTH_PASSWORD = "testpassword"
+
+
+@pytest.fixture
+def basic_auth_valid_authorization_token():
+    encoded = b64encode(b"testusername:testpassword").decode()
+    return f"Basic {encoded}"

--- a/manage_breast_screening/core/middleware.py
+++ b/manage_breast_screening/core/middleware.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseForbidden
+
+from manage_breast_screening.core.utils.auth import parse_basic_auth
+
+
+class BasicAuthMiddleware:
+    """
+    Perform HTTP basic authentication on any requests where the user is not already
+    logged in.
+
+    This middleware is enabled in public-facing, non-production environments where
+    data confidentiality is not needed, but we don't want people confusing
+    the app with a real service. It's not intended as a secure authentication
+    mechanism.
+
+    This does not interact with django.contrib.auth and so the user is still
+    considered "logged out" after entering valid credentials.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not settings.BASIC_AUTH_ENABLED:
+            return self.get_response(request)
+
+        if "HTTP_AUTHORIZATION" not in request.META:
+            # Send the basic authentication challenge
+            return HttpResponse(
+                status=401,
+                headers={
+                    "WWW-Authenticate": f"Basic realm='{settings.BASIC_AUTH_REALM}'"
+                },
+            )
+
+        # Parse the authorization header
+        auth = request.META["HTTP_AUTHORIZATION"]
+        try:
+            username, password = parse_basic_auth(auth)
+        except ValueError:
+            return HttpResponseForbidden()
+
+        if (
+            username == settings.BASIC_AUTH_USERNAME
+            and password == settings.BASIC_AUTH_PASSWORD
+        ):
+            return self.get_response(request)
+
+        return HttpResponseForbidden()

--- a/manage_breast_screening/core/tests/test_middleware.py
+++ b/manage_breast_screening/core/tests/test_middleware.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+class TestBasicAuthMiddleware:
+    @pytest.fixture(
+        autouse=True,
+    )
+    def setup(self, set_basic_auth_credentials, settings):
+        settings.MIDDLEWARE = [
+            "manage_breast_screening.core.middleware.BasicAuthMiddleware",
+        ]
+
+    def test_basic_auth_challenge(self, client):
+        response = client.get(reverse("clinics:index"))
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == "Basic realm=''"
+
+    def test_valid_login(self, client, basic_auth_valid_authorization_token):
+        response = client.get(
+            reverse("clinics:index"),
+            headers={"Authorization": basic_auth_valid_authorization_token},
+        )
+        assert response.status_code == 200
+
+    def test_invalid_login(self, client):
+        response = client.get(
+            reverse("clinics:index"),
+            headers={"Authorization": ""},
+        )
+        assert response.status_code == 403
+
+    def test_basic_auth_disabled(self, client, settings):
+        settings.BASIC_AUTH_ENABLED = False
+        response = client.get(
+            reverse("clinics:index"),
+            headers={"Authorization": ""},
+        )
+        assert response.status_code == 200

--- a/manage_breast_screening/core/tests/utils/test_auth.py
+++ b/manage_breast_screening/core/tests/utils/test_auth.py
@@ -1,0 +1,27 @@
+import base64
+
+import pytest
+
+from manage_breast_screening.core.utils.auth import parse_basic_auth
+
+
+class TestParseBasicAuth:
+    def test_valid(self):
+        assert parse_basic_auth("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==") == (
+            "Aladdin",
+            "open sesame",
+        )
+
+    def test_invalid_scheme(self):
+        with pytest.raises(ValueError):
+            parse_basic_auth("Another QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+
+    def test_invalid_base64(self):
+        with pytest.raises(ValueError):
+            parse_basic_auth("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=")
+
+    def test_invalid_encoded_contents(self):
+        encoded = base64.b64encode(b"opensesame")
+
+        with pytest.raises(ValueError):
+            parse_basic_auth(f"Basic {encoded}")

--- a/manage_breast_screening/core/utils/auth.py
+++ b/manage_breast_screening/core/utils/auth.py
@@ -1,0 +1,43 @@
+import base64
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+
+
+def parse_basic_auth(auth):
+    """
+    Helper to parse a HTTP_AUTHORIZATION header for basic authentication
+
+    See https://datatracker.ietf.org/doc/html/rfc7617
+    """
+    scheme, encoded_string = auth.split()
+
+    if scheme.lower() != "basic":
+        raise ValueError
+
+    username, password = base64.b64decode(encoded_string).decode("utf-8").split(":", 1)
+
+    return username, password
+
+
+class BasicAuthSettingsBackend(ModelBackend):
+    """
+    A simple auth backend that checks that the username and password
+    match the settings for basic auth. This should only be used in
+    non-production environments that do not require secure authentication.
+    """
+
+    def authenticate(self, _request, username=None, password=None, **kwargs):
+        if not settings.BASIC_AUTH_ENABLED:
+            return None
+
+        if (
+            username == settings.BASIC_AUTH_USERNAME
+            and password == settings.BASIC_AUTH_PASSWORD
+        ):
+            user = get_user_model().objects.filter(username=username).first()
+            if self.user_can_authenticate(user):
+                return user
+
+        return None

--- a/manage_breast_screening/mammograms/tests/jinja2/test_special_appointment_banner.py
+++ b/manage_breast_screening/mammograms/tests/jinja2/test_special_appointment_banner.py
@@ -38,13 +38,13 @@ def test_special_appointment_banner_with_change_link(jinja_env, presenter):
                 Special appointment
             </span></h3>
 
-            <dl class="nhsuk-summary-list nhsuk-summary-list">
+            <dl class="nhsuk-summary-list special-appointment-banner">
                 <div class="nhsuk-summary-list__row">
                     <dt class="nhsuk-summary-list__key">
                     Physical restriction
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                    broken foot<br><span class="nhsuk-tag nhsuk-tag--white nhsuk-u-margin-top-2">Temporary</span>
+                    broken foot<br><span class="special-appointment-banner__temporary">Temporary</span>
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row">
@@ -52,11 +52,11 @@ def test_special_appointment_banner_with_change_link(jinja_env, presenter):
                     Social, emotional, and mental health
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                    <span style="color: var(--nhsuk-secondary-text-color);">No details provided</span>
+                    <span class="special-appointment-banner__no-details">No details provided</span>
                     </dd>
                 </div>
             </dl>
-            <div style="text-align: right;">
+            <div class="special-appointment-banner__action">
                 <a href="/mammograms/68d758d0-792d-430f-9c52-1e7a0c2aa1dd/special-appointment/" style="font-size: 19px;">Change<span class="nhsuk-u-visually-hidden"> special appointment requirements</span></a>
             </div>
         </div>
@@ -85,13 +85,13 @@ def test_special_appointment_banner_without_change_link(jinja_env, presenter):
                 Special appointment
             </span></h3>
 
-            <dl class="nhsuk-summary-list nhsuk-summary-list">
+            <dl class="nhsuk-summary-list special-appointment-banner">
                 <div class="nhsuk-summary-list__row">
                     <dt class="nhsuk-summary-list__key">
                     Physical restriction
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                    broken foot<br><span class="nhsuk-tag nhsuk-tag--white nhsuk-u-margin-top-2">Temporary</span>
+                    broken foot<br><span class="special-appointment-banner__temporary">Temporary</span>
                     </dd>
                 </div>
                 <div class="nhsuk-summary-list__row">
@@ -99,7 +99,7 @@ def test_special_appointment_banner_without_change_link(jinja_env, presenter):
                     Social, emotional, and mental health
                     </dt>
                     <dd class="nhsuk-summary-list__value">
-                    <span style="color: var(--nhsuk-secondary-text-color);">No details provided</span>
+                    <span class="special-appointment-banner__no-details">No details provided</span>
                     </dd>
                 </div>
             </dl>


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description
This PR adds middleware that authenticates using HTTP basic authentication, configured by environment variables.

<img width="311" height="243" alt="Screenshot of basic authentication prompt" src="https://github.com/user-attachments/assets/8c741c78-07ac-47f1-b903-059c68e8f02d" />


This is not integrated with [django.contrib.auth](https://docs.djangoproject.com/en/5.2/ref/contrib/auth/) - so `request.user.is_authenticated` is still False after submitting valid credentials.

The plan is to introduce a separate page that will allow you to choose the persona you want to log in as. This will only be available on non-production environments.

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10297

## Review notes
For context - [here is my earlier approach](https://github.com/NHSDigital/dtos-manage-breast-screening/pull/243), which logged in a user if the basic auth was successful.