### PR TITLE
DTOSS-10349: Only send Appointments to Notify with Booked status

### DIFF
--- a/manage_breast_screening/notifications/management/commands/send_message_batch.py
+++ b/manage_breast_screening/notifications/management/commands/send_message_batch.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
 
             self.stdout.write("Finding appointments to include in batch...")
             appointments = Appointment.objects.filter(
-                starts_at__lte=self.schedule_date(), message__isnull=True
+                starts_at__lte=self.schedule_date(), message__isnull=True, status="B"
             )
 
             if not appointments:

--- a/manage_breast_screening/notifications/tests/factories.py
+++ b/manage_breast_screening/notifications/tests/factories.py
@@ -23,6 +23,7 @@ class AppointmentFactory(DjangoModelFactory):
     clinic = SubFactory(ClinicFactory)
     nhs_number = Sequence(lambda n: int("999%06d" % n))
     starts_at = datetime.now() + timedelta(weeks=4, days=4)
+    status = "B"
 
 
 class MessageFactory(DjangoModelFactory):


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

The MESH Inbox will be updated from NBSS when certain actions have been performed on an Appointment - Booked, Cancelled or Updated. The appointment `status` field will be one of:

'B' = Booked
'C' = Cancelled
'A' = Attended
'D' = DNA

We (currently) only want to send invites to participants if the Appointment is Booked, as that is the scope of our private beta work.

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10349?workflowName=DTOSS%3A+Task+Workflow+v2&stepId=2

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
