### PR TITLE
[DTOSS-10410] extract IntegerField subclass

### DIFF
--- a/manage_breast_screening/core/form_fields.py
+++ b/manage_breast_screening/core/form_fields.py
@@ -103,9 +103,9 @@ class SplitDateField(forms.MultiValueField):
         }
 
         self.fields = [
-            forms.IntegerField(**day_kwargs),
-            forms.IntegerField(**month_kwargs),
-            forms.IntegerField(**year_kwargs),
+            IntegerField(**day_kwargs),
+            IntegerField(**month_kwargs),
+            IntegerField(**year_kwargs),
         ]
 
         super().__init__(self.fields, *args, **kwargs)
@@ -172,5 +172,33 @@ class CharField(forms.CharField):
         # Don't use maxlength even if there is a max length validator.
         # This attribute prevents the user from seeing errors, so we don't use it
         attrs.pop("maxlength", None)
+
+        return attrs
+
+
+class IntegerField(forms.IntegerField):
+    def __init__(
+        self,
+        *args,
+        hint=None,
+        label_classes=None,
+        classes=None,
+        **kwargs,
+    ):
+        kwargs["template_name"] = "forms/input.jinja"
+
+        self.hint = hint
+        self.classes = classes
+        self.label_classes = label_classes
+
+        super().__init__(*args, **kwargs)
+
+    def widget_attrs(self, widget):
+        attrs = super().widget_attrs(widget)
+
+        # Don't use min/max/step attributes.
+        attrs.pop("min", None)
+        attrs.pop("max", None)
+        attrs.pop("step", None)
 
         return attrs

--- a/manage_breast_screening/core/tests/test_form_fields.py
+++ b/manage_breast_screening/core/tests/test_form_fields.py
@@ -6,7 +6,7 @@ from django.forms import Form
 from django.forms.widgets import TelInput, Textarea, TextInput
 from pytest_django.asserts import assertHTMLEqual
 
-from ..form_fields import CharField, SplitDateField
+from ..form_fields import CharField, IntegerField, SplitDateField
 
 
 class TestSplitDateField:
@@ -345,4 +345,25 @@ class TestCharField:
                     <textarea class="nhsuk-textarea" id="id_textfield_simple" name="textfield_simple" rows=" 10 "></textarea>
                 </div>
                 """,
+        )
+
+
+class TestIntegerField:
+    @pytest.fixture
+    def form_class(self):
+        class TestForm(Form):
+            field = IntegerField(label="Abc", initial=1, max_value=10)
+
+        return TestForm
+
+    def test_renders_nhs_input(self, form_class):
+        assertHTMLEqual(
+            form_class()["field"].as_field_group(),
+            """
+            <div class="nhsuk-form-group">
+                <label class="nhsuk-label" for="id_field">
+                    Abc
+                </label><input class="nhsuk-input" id="id_field" name="field" type="number" value="1">
+            </div>
+            """,
         )


### PR DESCRIPTION
## Description
Following on from https://github.com/NHSDigital/dtos-manage-breast-screening/pull/230

This extends the form field subclasses to include integer fields.

This one is not actually used directly in any templates at the moment, but I wanted to include it for completeness.

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10410

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
