### PR TITLE
Limit secret scanning in CI to the commits on the branch

### DIFF
--- a/.github/workflows/scan-repository.yaml
+++ b/.github/workflows/scan-repository.yaml
@@ -1,0 +1,18 @@
+name: 'Scan repository'
+
+on:
+  schedule:
+    - cron: '0 9 * * MON-FRI'
+
+jobs:
+  scan-secrets:
+    name: 'Scan secrets'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history is needed to scan all commits
+      - name: 'Scan secrets'
+        uses: ./.github/actions/scan-secrets

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -39,9 +39,19 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full history is needed to scan all commits
+          # By default, the checkout action just checks out the latest commit, creating a "shallow" clone.
+          # If we only scanned the latest commit, we might miss leaks that are not in the latest commit
+          # but are still present in previous commits on the branch.
+          #
+          # We don't want to checkout (and scan) the entire repository though, because that would mean
+          # 'bad' commits (including false-positives) block the CI for unrelated PRs, even if they're not
+          # on main, or part of the new branch.
+          #
+          # To keep PRs independent of each other, we can fetch with an "infinite" depth, rather than
+          # the special 0 value of actions/checkout, which means "fetch all history for all tags and branches"
+          depth: 0x7fffffff # INFINITE_DEPTH
+        uses: actions/checkout@v4
       - name: 'Scan secrets'
         uses: ./.github/actions/scan-secrets
   scan-dependencies:


### PR DESCRIPTION
## Description
On the PR-triggered workflow, only run commit scans on commits reachable from the current branch. Do not include unrelated branches.

In a separate, scheduled workflow, do a full scan. (I will set up slack notifications for this shortly).

This should prevent issues with PRs being blocked unnecessarily. E.g. right now we have a false-positive added and fixed in one branch, but all other PRs are failing their CI because they don't have the exception in their .gitleaksignore.

As far as I can tell, `actions/checkout` doesn't provide a nice way to say "fetch all the commits between the main branch (or merge base) and the current branch" - see https://github.com/actions/checkout/issues/520 for a discussion of the workarounds.