### PR TITLE
DTOSS- 10575 - add recoverable failures to retry queue

### DIFF
--- a/manage_breast_screening/notifications/services/queue.py
+++ b/manage_breast_screening/notifications/services/queue.py
@@ -20,3 +20,7 @@ class Queue:
     @classmethod
     def MessageStatusUpdates(cls):
         return cls("message_status_updates")
+
+    @classmethod
+    def RetryMessageBatches(cls):
+        return cls("retry_message_batches")

--- a/manage_breast_screening/notifications/tests/factories.py
+++ b/manage_breast_screening/notifications/tests/factories.py
@@ -1,8 +1,9 @@
 import uuid
 from datetime import datetime, timedelta
 
-from factory import Sequence, SubFactory, post_generation
+from factory.declarations import Sequence, SubFactory
 from factory.django import DjangoModelFactory
+from factory.helpers import post_generation
 
 from manage_breast_screening.notifications.management.commands.send_message_batch import (
     TZ_INFO,
@@ -41,6 +42,7 @@ class MessageFactory(DjangoModelFactory):
 class MessageBatchFactory(DjangoModelFactory):
     class Meta:
         model = models.MessageBatch
+        skip_postgeneration_save = True
 
     routing_plan_id = str(uuid.uuid4())
     status = "unscheduled"

--- a/manage_breast_screening/notifications/tests/services/test_queue.py
+++ b/manage_breast_screening/notifications/tests/services/test_queue.py
@@ -49,3 +49,18 @@ class TestQueue:
             )
             mock_client.create_queue.assert_called_once()
             mock_client.send_message.assert_called_once_with("some data")
+
+    def test_failed_message_batches_queue(self):
+        with patch(
+            "manage_breast_screening.notifications.services.queue.QueueClient"
+        ) as queue_client:
+            mock_client = MagicMock()
+            queue_client.from_connection_string.return_value = mock_client
+
+            Queue.RetryMessageBatches().add("some data")
+
+            queue_client.from_connection_string.assert_called_once_with(
+                "qqq111", "retry_message_batches"
+            )
+            mock_client.create_queue.assert_called_once()
+            mock_client.send_message.assert_called_once_with("some data")


### PR DESCRIPTION
~~CI is currently broken so having to stack PR's temporarily! This builds on this first PR https://github.com/NHSDigital/dtos-manage-breast-screening/pull/278~~

<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

If a MessageBatch fails to send for a recoverable reason, as declared currently in `send_message_batch`, then we send it to a queue to retry failed batches.

In future some code will be able to process the queue and determine what next steps are for the batch - e.g. if one Message has a validation error then we remove that Message. Or if the error was recoverable (e.g. a server timeout) then we just go ahead and retry.

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10575

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
