### PR TITLE
Exclude notifications integration tests from unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ help: # Print help @Others
 test: test-unit test-ui test-lint # Run all tests @Testing
 
 test-unit: # Run unit tests @Testing
-	poetry run pytest -m 'not system and not integration' --ignore manage_breast_screening/notifications/tests/dependencies --cov --cov-report term-missing:skip-covered
+	poetry run pytest -m 'not system' --ignore manage_breast_screening/notifications/tests/dependencies --ignore manage_breast_screening/notifications/tests/integration --cov --cov-report term-missing:skip-covered
 	npm test -- --coverage
 
 test-lint: # Lint files @Testing

--- a/manage_breast_screening/notifications/tests/management/commands/test_send_message_batch.py
+++ b/manage_breast_screening/notifications/tests/management/commands/test_send_message_batch.py
@@ -143,7 +143,7 @@ class TestSendMessageBatch:
         assert messages.count() == 1
         assert messages[0].appointment == valid_appointment
 
-    @pytest.mark.parametrize("status_code", [401, 403, 404, 405, 406, 415, 422])
+    @pytest.mark.parametrize("status_code", [401, 403, 404, 405, 406, 413, 415, 422])
     @pytest.mark.django_db
     def test_handle_with_unrecoverable_failures(
         self, mark_batch_as_sent, mock_send_message_batch, routing_plan_id, status_code
@@ -170,7 +170,7 @@ class TestSendMessageBatch:
         assert messages.count() == 1
         assert messages[0].status == "failed"
 
-    @pytest.mark.parametrize("status_code", [400, 408, 413, 425, 429, 500, 503, 504])
+    @pytest.mark.parametrize("status_code", [400, 408, 425, 429, 500, 503, 504])
     @pytest.mark.django_db
     def test_handle_with_recoverable_failures(
         self, mark_batch_as_sent, mock_send_message_batch, routing_plan_id, status_code


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Main branch tests are broken and this appears to have been masked by how the unit test suite collects tests.
We should not run notifications integration tests as part of the unit test suite as they rely on containerised dependencies. For some reason (possibly the `pytest -m` flag) these were collected and ran but were not failing the suite.

This PR:

- Explicitly excludes notifications integration tests from the unit test suite.
- Fixes broken unit test.

<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
