### PR TITLE
fix SHELLFLAGS typo that prevents exiting on first failure

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/stage-4-deploy.yaml
     with:
-      environments: "[\"review\"]"
+      environments: '["review"]'
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets: inherit
@@ -92,10 +92,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - name: Post URL to PR comments
-      uses: marocchino/sticky-pull-request-comment@8ac02941f254c53fbda0cf44288785e1367e13bf
-      with:
-        message: |
-          The review app is available at this URL:
-          https://pr-${{ github.event.pull_request.number }}.manage-breast-screening.non-live.screening.nhs.uk
-          You must authenticate with Entra ID
+      - name: Post URL to PR comments
+        uses: marocchino/sticky-pull-request-comment@8ac02941f254c53fbda0cf44288785e1367e13bf
+        with:
+          message: |
+            The review app is available at this URL:
+            https://pr-${{ github.event.pull_request.number }}.manage-breast-screening.non-live.screening.nhs.uk
+            You must authenticate with Entra ID

--- a/.github/workflows/cicd-2-main-branch.yaml
+++ b/.github/workflows/cicd-2-main-branch.yaml
@@ -85,6 +85,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/stage-4-deploy.yaml
     with:
-      environments: "[\"review\",\"dev\"]"
+      environments: '["review","dev"]'
       commit_sha: ${{ github.sha }}
     secrets: inherit

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,7 @@
     "MD024": { "siblings_only": true },
     "MD033": false
   },
-  "python.testing.pytestArgs": [
-    "."
-  ],
+  "python.testing.pytestArgs": ["."],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For more information, see the following developer guides:
 - [Scripting Docker](https://github.com/NHSDigital/repository-template/blob/main/docs/developer-guides/Scripting_Docker.md)
 
 ### More documentation
+
 Explore [the docs directory](docs).
 
 ## Licence

--- a/docs/adr/ADR-003-Subclass_Django_Form_fields.md
+++ b/docs/adr/ADR-003-Subclass_Django_Form_fields.md
@@ -18,20 +18,21 @@ This was very error prone and verbose, because we had to map between Django's fo
 
 We decided to introduce a set of `Field` subclasses that customise the internal templates, so that they are rendered using the design system components.
 
-| Field class | Widget class | Rendered component |
-| -- | -- | -- |
-| core.form_fields.CharField | TextInput, EmailInput, etc | input |
-| core.form_fields.CharField | TextArea | textarea |
-| core.form_fields.ChoiceField | RadioSelect | radios |
-| core.form_fields.ChoiceField | Select | select |
-| core.form_fields.MultipleChoiceField | CheckboxSelectMultiple | checkboxes |
-| core.form_fields.SplitDateField | SplitDateWidget | date-input |
+| Field class                          | Widget class               | Rendered component |
+| ------------------------------------ | -------------------------- | ------------------ |
+| core.form_fields.CharField           | TextInput, EmailInput, etc | input              |
+| core.form_fields.CharField           | TextArea                   | textarea           |
+| core.form_fields.ChoiceField         | RadioSelect                | radios             |
+| core.form_fields.ChoiceField         | Select                     | select             |
+| core.form_fields.MultipleChoiceField | CheckboxSelectMultiple     | checkboxes         |
+| core.form_fields.SplitDateField      | SplitDateWidget            | date-input         |
 
 In a template, they are rendered with `{{ form.field.as_field_group() }}` this encpauslates all the complexity of mapping parameters between Django's form API and the [Jinja2 component macros](./ADR-002-Use_Jinja2.md).
 
 ## Consequences
 
 the custom form field subclasses:
+
 - make it possible to add new forms without writing a lot of HTML or Jinja in the template
 - should be intuitive to developers already familiar with Django
 - may need extending to support additional params for the underlying component

--- a/docs/infrastructure/create-environment.md
+++ b/docs/infrastructure/create-environment.md
@@ -3,81 +3,87 @@
 This is the initial manual process to create a new environment like review, dev, production...
 
 ## Code
+
 - Create the configuration files in `infrastructure/environments/[environment]`
 - Add the `[environment]:` target in `scripts/terraform/terraform.mk`
 - Add [environment] to the list of environments in `deploy-stage` step of `cicd-2-main-branch.yaml`. For the review enviornment, there is a single item in `cicd-1-pull-request.yaml`.
 - Set the `fetch_secrets_from_app_key_vault` terraform variable to `false`. This is to let terraform create the key vault and prevent reading before it is ready.
 
 ## Entra ID
+
 - Create postgres Entra ID group in `DTOS Administrative Unit (AU)`: `postgres_manbrs_[environment]_uks_admin`
 - Ask CCOE to assign role:
-	- [Form for PIM](https://nhsdigitallive.service-now.com/nhs_digital?id=sc_cat_item&sys_id=28f3ab4f1bf3ca1078ac4337b04bcb78&sysparm_category=114fced51bdae1502eee65b9bd4bcbdc)
-	- Approver: Add someone from the infrastructure team
-	- Role Name: `Group.Read.All`
-	- Application Name: `mi-manbrs-[environment]-adotoaz-uks`
-	- Application ID: [client.id]
-	- Managed identity: `mi-manbrs-[environment]-adotoaz-uks`
-	- Description:
-    	- Managed identity: `mi-manbrs-[environment]-adotoaz-uks`
-    	- Role: permanent on Directory
+  - [Form for PIM](https://nhsdigitallive.service-now.com/nhs_digital?id=sc_cat_item&sys_id=28f3ab4f1bf3ca1078ac4337b04bcb78&sysparm_category=114fced51bdae1502eee65b9bd4bcbdc)
+  - Approver: Add someone from the infrastructure team
+  - Role Name: `Group.Read.All`
+  - Application Name: `mi-manbrs-[environment]-adotoaz-uks`
+  - Application ID: [client.id]
+  - Managed identity: `mi-manbrs-[environment]-adotoaz-uks`
+  - Description: - Managed identity: `mi-manbrs-[environment]-adotoaz-uks` - Role: permanent on Directory
 
 ## Bicep
+
 - Run bicep from AVD: `make [environment] resource-group-init`
 
 ## Infra secrets
-- Add the infrastructure secrets to the *inf* key vault `kv-manbrs-[review]-inf`
+
+- Add the infrastructure secrets to the _inf_ key vault `kv-manbrs-[review]-inf`
 
 ## Azure devops
+
 - Create ADO group
-	- Name: `Run pipeline - [environment]`
-	- Members: `mi-manbrs-[environment]-ghtoado-uks`. There may be more than 1 in the list. Check client id printed below the name.
-	- Permissions:
-		- View project-level information
+  - Name: `Run pipeline - [environment]`
+  - Members: `mi-manbrs-[environment]-ghtoado-uks`. There may be more than 1 in the list. Check client id printed below the name.
+  - Permissions:
+    - View project-level information
 - Create new pipeline:
-    - Name: `Deploy to Azure - [environment]`
-    - Pipeline yaml: `.azuredevops/pipelines/deploy.yml`
+  - Name: `Deploy to Azure - [environment]`
+  - Pipeline yaml: `.azuredevops/pipelines/deploy.yml`
 - Manage pipeline security:
-	- Add group: `Run pipeline - [environment]`
-	- Permissions:
-		- Edit queue build configuration
-		- Queue builds
-		- View build pipeline
-		- View builds
+  - Add group: `Run pipeline - [environment]`
+  - Permissions:
+    - Edit queue build configuration
+    - Queue builds
+    - View build pipeline
+    - View builds
 - Create service connection (ADO)
-	- Connection type: `Azure Resource Manager`
-	- Identity type: `Managed identity`
-	- Subscription for managed identity: `Digital Screening DToS - Devops`
-	- Resource group for managed identity: `rg-mi-[environment]-uks`
-	- Managed identity: `mi-manbrs-[environment]-adotoaz-uks`
-	- Scope level: `Subscription`
-	- Subscription: `Digital Screening DToS - Core Services Dev`
-	- Resource group for Service connection: leave blank
-	- Service Connection Name: `manbrs-[environment]`
-	- Do NOT tick: Grant access permission to all pipelines
-	- Security: allow `Deploy to Azure - [environment]` pipeline
+  - Connection type: `Azure Resource Manager`
+  - Identity type: `Managed identity`
+  - Subscription for managed identity: `Digital Screening DToS - Devops`
+  - Resource group for managed identity: `rg-mi-[environment]-uks`
+  - Managed identity: `mi-manbrs-[environment]-adotoaz-uks`
+  - Scope level: `Subscription`
+  - Subscription: `Digital Screening DToS - Core Services Dev`
+  - Resource group for Service connection: leave blank
+  - Service Connection Name: `manbrs-[environment]`
+  - Do NOT tick: Grant access permission to all pipelines
+  - Security: allow `Deploy to Azure - [environment]` pipeline
 - Create ADO environment: [environment]
-	- Set: exclusive lock (except for review)
-	- Add pipeline permission for `Deploy to Azure - [environment]` pipeline
+  - Set: exclusive lock (except for review)
+  - Add pipeline permission for `Deploy to Azure - [environment]` pipeline
 
 ## Github
+
 - Create Github environment [environment]
 - Add the protection rule (except in review):
-	- Deselect `Allow administrators to bypass configured protection rules`
-	- In `Deployment branches and tags` choose `Selected branches and tags` from the drop-down menu
-	- Click `Add deployment branch or tag rule` and enter "main"
+  - Deselect `Allow administrators to bypass configured protection rules`
+  - In `Deployment branches and tags` choose `Selected branches and tags` from the drop-down menu
+  - Click `Add deployment branch or tag rule` and enter "main"
 - Add environment secrets, from `mi-manbrs-[environment]-ghtoado-uks` in github
-	- *AZURE_CLIENT_ID*
-	- *AZURE_SUBSCRIPTION_ID*
+  - _AZURE_CLIENT_ID_
+  - _AZURE_SUBSCRIPTION_ID_
 
 ## First run
+
 - Test running terraform manually from the AVD (Optional)
 - Raise a pull request, review and merge to trigger the pipeline
 - Check ADO pipeline. You may be prompted to authorise:
-	- Pipeline: service connection
-	- Environment: service connection and agent pool
+  - Pipeline: service connection
+  - Environment: service connection and agent pool
 
 ## App secrets
-- Add the application secrets to the *app* key vault `kv-manbrs-[review]-app`
+
+- Add the application secrets to the _app_ key vault `kv-manbrs-[review]-app`
 - Set `fetch_secrets_from_app_key_vault` terraform variable to `true`
 - Test running terraform manually from the AVD (Optional)
 - Raise a pull request, review and merge to trigger the pipeline

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -1,6 +1,7 @@
 # Deployment
 
 ## Infrastructure
+
 The code is packaged into a docker image which is deployed to [Azure container apps](https://learn.microsoft.com/en-us/azure/container-apps/). The main app is a web application, with an HTTP ingress. And the second one is an [Azure container app job](https://learn.microsoft.com/en-us/azure/container-apps/jobs?tabs=azure-cli), triggered on demand to run the database migration.
 
 The web application does not have a public endpoint. It is only accessible via [Azure front door](https://learn.microsoft.com/en-us/azure/frontdoor/) which is a CDN providing TLS certificates, firewall, scaling and caching. The internal endpoint is accessible via [Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/).
@@ -8,17 +9,22 @@ The web application does not have a public endpoint. It is only accessible via [
 The data is hosted on [Azure postgres flexible server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview).
 
 ## Docker build
+
 The build pipeline builds and pushes a docker image to [Github container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). The image is tagged with:
+
 - branch name: for docker build caching
 - commit SHA: to uniquely identify the image during deployment, prefixed by "git-sha-".
 - image digest sha: immutable tag
 
 ## Automated deployment
+
 The deployment is split between:
+
 - [Github actions](https://github.com/features/actions) for Continuous Integration (CI)
 - [Azure devops](https://azure.microsoft.com/en-us/products/devops) pipelines for Continuous Deployment (CD)
 
 ### Github actions
+
 Runs on Github hosted runners on the internet. They run all our tests (unit, functional, security, linting...). They don't have access to our internal network nor any sensitive data.
 
 To deploy an environment, they authenticate to Azure and delegate the work to [Azure devops piplines](#azure-devops-pipelines).
@@ -26,30 +32,36 @@ To deploy an environment, they authenticate to Azure and delegate the work to [A
 See [all Github actions](https://github.com/NHSDigital/dtos-manage-breast-screening/actions).
 
 ### Azure devops pipelines
+
 We use a public repository as required by the [NHS Service standard](https://service-manual.nhs.uk/standards-and-technology/service-standard-points/12-make-new-source-code-open). For security reasons, deployments cannot run from Github actions and run instead on Azure devops private runners inside our internal network. They have access to the network and any Azure resource deployed onto it.
 
 See [all Azure devops pipelines](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build).
 
 ### Review apps
-When a pull request is raised, add a "deploy" label to deploy a *review app* (concept borrowed from [Heroku](https://devcenter.heroku.com/articles/github-integration-review-apps)). It triggers the [CI/CD pull request](https://github.com/NHSDigital/dtos-manage-breast-screening/actions/workflows/cicd-1-pull-request.yaml) Github action workflow, which runs tests then authenticates to Azure and triggers the [Deploy review app](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build?definitionId=102) Azure devops pipeline. It runs terraform to deploy the application, database and front door configuration.
+
+When a pull request is raised, add a "deploy" label to deploy a _review app_ (concept borrowed from [Heroku](https://devcenter.heroku.com/articles/github-integration-review-apps)). It triggers the [CI/CD pull request](https://github.com/NHSDigital/dtos-manage-breast-screening/actions/workflows/cicd-1-pull-request.yaml) Github action workflow, which runs tests then authenticates to Azure and triggers the [Deploy review app](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build?definitionId=102) Azure devops pipeline. It runs terraform to deploy the application, database and front door configuration.
 
 To make this process faster and less costly, most of the infrastructure is reused for all review apps: networking, key vaults, container app environments... The base infrastructure is only updated by the pipeline on the main branch.
 
-When the pull request is closed or merged, and if it has the "deploy" label, the [Delete review app](https://github.com/NHSDigital/dtos-manage-breast-screening/actions/workflows/cicd-1-pull-request-closed.yaml) workflow is triggered, followed by the [Delete review app](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build?definitionId=103) Azure devops pipeline. It runs *terraform destroy* to delete the resources.
+When the pull request is closed or merged, and if it has the "deploy" label, the [Delete review app](https://github.com/NHSDigital/dtos-manage-breast-screening/actions/workflows/cicd-1-pull-request-closed.yaml) workflow is triggered, followed by the [Delete review app](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build?definitionId=103) Azure devops pipeline. It runs _terraform destroy_ to delete the resources.
 
 Note: terraform currently deploys a postgres server with a locked database. It must be deleted manually from the Azure portal before the pipeline runs.
 
 ### Main branch
+
 When a pull request is merged to the main branch, the [CI/CD main branch](https://github.com/NHSDigital/dtos-manage-breast-screening/actions/workflows/cicd-2-main-branch.yaml) is triggered. It runs tests then authenticates to Azure and triggers the [Deploy to Azure](https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build?definitionId=93) Azure devops pipeline. It runs terraform to deploy the entire environment, including both infrastructure and applications. Any manual change is overwritten by terraform.
 
 ## Application secrets
-The application requires secrets provided as environment variables. Terraform creates an *app* Azure key vault and all its secrets are mapped directly to the app as environment variables. Developers can access the key vault to create and update the secrets manually.
+
+The application requires secrets provided as environment variables. Terraform creates an _app_ Azure key vault and all its secrets are mapped directly to the app as environment variables. Developers can access the key vault to create and update the secrets manually.
 
 Notes:
+
 - [the process requires multiple steps](https://github.com/NHSDigital/dtos-devops-templates/tree/main/infrastructure/modules/container-app#key-vault-secrets) to set up an environment initially. The process is documented in [create-environment](create-environment.md).
 - The secrets names in key vault are uppercase with hyphen separators. They are mapped to environment variables as uppercase with underscore separator. e.g. `SECRET-KEY` is mapped to `SECRET_KEY`.
 
 ## Manual deployment
+
 For each environment, e.g. 'dev':
 
 1. Connect to [Azure virtual desktop](https://azure.microsoft.com/en-us/products/virtual-desktop). Ask the platform team for access with Administrator role.
@@ -73,7 +85,8 @@ For each environment, e.g. 'dev':
 [Review app environments](#review-apps) differ slightly from other environments. They are lightweight versions of the application and are designed to share much of the core Azure infrastructure. As a result, there is a one-to-many relationship between the container apps and the container app environment.
 
 ### Step 1
-If you run the following command *without* the `PR_NUMBER` parameter, it will apply only the infrastructure module:
+
+If you run the following command _without_ the `PR_NUMBER` parameter, it will apply only the infrastructure module:
 
 ```shell
 make review terraform-apply
@@ -90,7 +103,9 @@ make review terraform-apply DOCKER_IMAGE_TAG=git-sha-01ecb79d561f55be60072a093dd
 ```
 
 ### Delete review app
+
 Run terraform-destroy:
+
 ```shell
 make review terraform-destroy DOCKER_IMAGE_TAG=git-sha-01ecb79d561f55be60072a093dd167fe8eb5b42e PR_NUMBER=123
 ```

--- a/docs/infrastructure/infra-faq.md
+++ b/docs/infrastructure/infra-faq.md
@@ -4,11 +4,12 @@
 - [Github action triggering Azure devops pipeline](#github-action-triggering-azure-devops-pipeline)
 - [Bicep errors](#bicep-errors)
 
-
 ## Terraform
+
 ### Import into terraform state file
 
 To import Azure resources into the Terraform state file, you can use the following command. If you're working on an AVD machine, you may need to set the environment variables:
+
 - `ARM_USE_AZUREAD` to use Azure AD instead of a shared key
 - `MSYS_NO_PATHCONV` to stop git bash from expanding file paths
 
@@ -22,7 +23,9 @@ terraform -chdir=infrastructure/terraform import  -var-file ../environments/${EN
 ```
 
 ### Error: Failed to load state
+
 This happens when running terraform commands accessing the state file like [import](#import-into-terraform-state-file), `state list` or `force-unlock`.
+
 ```
 Failed to load state: blobs.Client#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="KeyBasedAuthenticationNotPermitted" Message="Key based authentication is not permitted on this storage account.
 ```
@@ -34,8 +37,11 @@ ARM_USE_AZUREAD=true terraform force-unlock xxx-yyy
 ```
 
 ## Github action triggering Azure devops pipeline
-### Application with identifier '***' was not found in the directory
+
+### Application with identifier '\*\*\*' was not found in the directory
+
 Example:
+
 ```
 Running Azure CLI Login.
 ...
@@ -45,10 +51,13 @@ Error: AADSTS700016: Application with identifier '***' was not found in the dire
 Error: Interactive authentication is needed. Please run:
 az login
 ```
+
 The managed identity does not exist or Github secrets are not set correctly
 
-### The client '***' has no configured federated identity credentials
+### The client '\*\*\*' has no configured federated identity credentials
+
 Example:
+
 ```
 Running Azure CLI Login.
 ...
@@ -58,35 +67,47 @@ Error: AADSTS70025: The client '***'(mi-manbrs-ado-review-temp) has no configure
 Error: Interactive authentication is needed. Please run:
 az login
 ```
+
 Federated credentials are not configured.
 
-### No subscriptions found for ***
+### No subscriptions found for \*\*\*
+
 Example:
+
 ```
 Running Azure CLI Login.
 ...
 Attempting Azure CLI login by using OIDC...
 Error: No subscriptions found for ***.
 ```
+
 Give the managed identity Reader role on a subscription (normally Devops)
 
 ### Pipeline permissions
+
 Examples:
+
 ```
 ERROR: TF401444: Please sign-in at least once as ***\***\xxx in a web browser to enable access to the service.
 Error: Process completed with exit code 1.
 ```
+
 Or
+
 ```
 ERROR: TF400813: The user 'xxx' is not authorized to access this resource.
 Error: Process completed with exit code 1.
 ```
+
 Or
+
 ```
 ERROR: VS800075: The project with id 'vstfs:///Classification/TeamProject/' does not exist, or you do not have permission to access it.
 Error: Process completed with exit code 1.
 ```
+
 The Github secret must reflect the right managed identity, the managed identity must have the following permissions on the pipeline, via its ADO group:
+
 - Edit queue build configuration
 - Queue builds
 - View build pipeline
@@ -94,43 +115,59 @@ The Github secret must reflect the right managed identity, the managed identity 
 The ADO group must have the "View project-level information" permission.
 
 ### The service connection does not exist
+
 Example:
+
 ```
 The pipeline is not valid. Job DeployApp: Step input azureSubscription references service connection manbrs-review which could not be found. The service connection does not exist, has been disabled or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz. Job DeployApp: Step input azureSubscription references service connection manbrs-review which could not be found. The service connection does not exist, has been disabled or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.
 ```
+
 The Azure service connection manbrs-[environment] is missing
 
 ## Bicep errors
+
 ### RoleAssignmentUpdateNotPermitted
+
 Example:
+
 ```
 ERROR: {"status":"Failed","error":{"code":"DeploymentFailed","target":"/subscriptions/xxx/providers/Microsoft.Resources/deployments/main","message":"At least one reson failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"RoleAssignmentUpdateNotPermitted","message":"Tenprincipal ID, and scope are not allowed to be updated."},{"code":"RoleAssignmentUpdateNotPermitted","message":"Tenant ID, application ID, principal ID, and scope are not allowed to be updated."},{"cteNotPermitted","message":"Tenant ID, application ID, principal ID, and scope are not allowed to be updated."}]}}
 ```
+
 When deleting a MI, its role assignment is not deleted. When recreating the MI, bicep tries to update the role assignment and is not allowed to. Solution:
+
 - Find the role assignment id. Here: abcd-123
 - Navigate to subscriptions and resource group IAM and search for the role assignment id
 - Delete the role assignment via the portal
 
 If you can't find the right scope, follow this process:
+
 - Find the role assignment id. Here: abcd-123
+
 ```
  ~ Microsoft.Authorization/roleAssignments/abcd-123 [2022-04-01]
     ~ properties.principalId: "xxx" => "[reference('/subscriptions/xxx/resourceGroups/rg-mi-review-uks/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-manbrs-ado-review-uks', '2024-11-30').principalId]"
 ```
+
 - Get the subscription id
 - List role assignments: `az role assignment list --scope "/subscriptions/[subscription id]"`
 - Look for the role assignment id abcd-123 to retrieve the other details. It may named: Unknown.
 - Delete the role assignment via the portal
 
 ### PrincipalNotFound
+
 Example:
+
 ```
 ERROR: {"status":"Failed","error":{"code":"DeploymentFailed","target":"/subscriptions/exxx/providers/Microsoft.Resources/deployments/main","message":"At least one reson failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"PrincipalNotFound","message":"Principal xxx does not exist in the directory xxx. Check that you have the correct principal ID. If you are creating this principal and then immediately assigning a role, this era replication delay. In this case, set the role assignment principalType property to a value, such as ServicePrincipal, User, or Group.  See https://aka.ms/docs-principaltype"}...
 ```
+
 Race condition: the managed identity is not created in time for the resources that depend on it. Solution: rerun the command.
 
 ### The client does not have permission
+
 ```
 {"code": "InvalidTemplateDeployment", "message": "Deployment failed with multiple errors: 'Authorization failed for template resource 'xxx' of type 'Microsoft.Authorization/roleAssignments'. The client 'xxx' with object id 'xxx' does not have permission to perform action 'Microsoft.Authorization/roleAssignments/write' at scope '/subscriptions/xxx/providers/Microsoft.Authorization/roleAssignments/xxx'...
 ```
+
 Request Owner role on subscriptions via PIM.

--- a/manage_breast_screening/notifications/compose.yml
+++ b/manage_breast_screening/notifications/compose.yml
@@ -1,10 +1,9 @@
 name: manage-breast-screening-notifications
 
 services:
-
   azurite:
     container_name: azurite
-    command: "azurite --loose --skipApiVersionCheck --blobHost 0.0.0.0 --blobPort 10000 --queueHost 0.0.0.0 --queuePort 10001"
+    command: 'azurite --loose --skipApiVersionCheck --blobHost 0.0.0.0 --blobPort 10000 --queueHost 0.0.0.0 --queuePort 10001'
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
       - 10000:10000
@@ -18,7 +17,7 @@ services:
     build:
       context: https://github.com/NHSDigital/mesh-sandbox.git#refs/tags/v1.0.4
     ports:
-      - "8700:80"
+      - '8700:80'
     deploy:
       restart_policy:
         condition: on-failure
@@ -48,7 +47,7 @@ services:
       - development
       - integration
     ports:
-      - "8888:8888"
+      - '8888:8888'
     healthcheck:
       test: curl -f http://localhost:8888/health || exit 1
       interval: 3s
@@ -64,5 +63,4 @@ services:
       notify-api-stub:
         condition: service_healthy
     profiles:
-        - integration
-
+      - integration

--- a/manage_breast_screening/participants/tests/factories.py
+++ b/manage_breast_screening/participants/tests/factories.py
@@ -60,10 +60,12 @@ class ParticipantReportedMammogramFactory(DjangoModelFactory):
         outside_uk = Trait(
             location_type=models.ParticipantReportedMammogram.LocationType.OUTSIDE_UK,
             location_details="france",
+            provider=None,
         )
         elsewhere_uk = Trait(
             location_type=models.ParticipantReportedMammogram.LocationType.ELSEWHERE_UK,
             location_details="private provider",
+            provider=None,
         )
 
 

--- a/scripts/shared.mk
+++ b/scripts/shared.mk
@@ -68,4 +68,4 @@ shellscript-lint-all: # Lint all shell scripts in the scripts directory, do not 
 .ONESHELL:
 MAKEFLAGS := --no-print-directory
 SHELL := /bin/bash
-SHELLFLAGS := -cex
+.SHELLFLAGS := -cex


### PR DESCRIPTION
If `.ONESHELL` is set in a Makefile, the `-e` option [must be passed to the shell](https://www.gnu.org/software/make/manual/html_node/One-Shell.html). However, there was a typo in `.SHELLFLAGS` that prevented it from being picked up.

`-e` in bash means "Exit immediately if a command exits with a non-zero status."

Adding to the confusion, version 3.81 of make applied the `-e` behaviour regardless of the typo, but 3.82 onwards didn't, leading to different results on different machines.

Since we have phony tasks with multiple test commands in, this was allowing build failures to pass undetected.

I've tested the fix with a stripped down example:

    .PHONY: debug

    debug:
    	false
    	echo "This should not print"

    .ONESHELL:
    .SHELL := /bin/bash
    .SHELLFLAGS := -cex

This typo must have crept in when I stripped down the repository template's make scripts (to get it to work), as it's not present in the template.