### PR TITLE
Add failures report query

### DIFF
--- a/docs/infrastructure/create-environment.md
+++ b/docs/infrastructure/create-environment.md
@@ -9,7 +9,6 @@ This is the initial manual process to create a new environment like review, dev,
 - Add [environment] to the list of environments in `deploy-stage` step of `cicd-2-main-branch.yaml`. For the review environment, there is a single item in `cicd-1-pull-request.yaml`.
 - Set the `fetch_secrets_from_app_key_vault` terraform variable to `false`. This is to let terraform create the key vault and prevent reading before it is ready.
 
-
 ## Entra ID
 
 - Create postgres Entra ID group in `DTOS Administrative Unit (AU)`: `postgres_manbrs_[environment]_uks_admin`

--- a/manage_breast_screening/notifications/queries/failures.py
+++ b/manage_breast_screening/notifications/queries/failures.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from django.db.models import F, QuerySet
 
@@ -10,8 +11,9 @@ from manage_breast_screening.notifications.models import (
 
 class Failures:
     def query(self, date: datetime = datetime.today()) -> QuerySet:
-        starts_at = date.replace(hour=0, minute=0, second=0)
-        ends_at = date.replace(hour=23, minute=59, second=59)
+        tzinfo = ZoneInfo("Europe/London")
+        starts_at = date.replace(hour=0, minute=0, second=0, tzinfo=tzinfo)
+        ends_at = date.replace(hour=23, minute=59, second=59, tzinfo=tzinfo)
 
         return (
             MessageStatus.objects.filter(

--- a/manage_breast_screening/notifications/queries/failures.py
+++ b/manage_breast_screening/notifications/queries/failures.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from django.db.models import F, QuerySet
+
+from manage_breast_screening.notifications.models import (
+    MessageStatus,
+    MessageStatusChoices,
+)
+
+
+class Failures:
+    def query(self, date: datetime = datetime.today()) -> QuerySet:
+        starts_at = date.replace(hour=0, minute=0, second=0)
+        ends_at = date.replace(hour=23, minute=59, second=59)
+
+        return (
+            MessageStatus.objects.filter(
+                message__appointment__starts_at__gte=starts_at,
+                message__appointment__starts_at__lte=ends_at,
+                status=MessageStatusChoices.FAILED.value,
+            )
+            .values(
+                "message__appointment__nhs_number",
+                "message__appointment__starts_at",
+                "message__appointment__clinic__code",
+                "message__appointment__episode_type",
+                "status_updated_at",
+                "description",
+            )
+            .annotate(
+                nhs_number=F("message__appointment__nhs_number"),
+                appointment_date=F("message__appointment__starts_at"),
+                clinic_code=F("message__appointment__clinic__code"),
+                episode_type=F("message__appointment__episode_type"),
+                failure_date=F("status_updated_at"),
+                failure_reason=F("description"),
+            )
+        )

--- a/manage_breast_screening/notifications/tests/factories.py
+++ b/manage_breast_screening/notifications/tests/factories.py
@@ -1,4 +1,3 @@
-import secrets
 import uuid
 from datetime import datetime, timedelta
 
@@ -70,7 +69,7 @@ class ChannelStatusFactory(DjangoModelFactory):
     message = SubFactory(MessageFactory)
     status = "read"
     status_updated_at = datetime.now() - timedelta(minutes=10)
-    idempotency_key = Sequence(lambda n: f"{secrets.token_hex(18)}%09d" % n)
+    idempotency_key = Sequence(lambda n: f"{uuid.uuid4().hex}%03d" % n)
 
 
 class MessageStatusFactory(DjangoModelFactory):
@@ -81,4 +80,4 @@ class MessageStatusFactory(DjangoModelFactory):
     message = SubFactory(MessageFactory)
     status = "delivered"
     status_updated_at = datetime.now() - timedelta(minutes=10)
-    idempotency_key = Sequence(lambda n: f"{secrets.token_hex(18)}%09d" % n)
+    idempotency_key = Sequence(lambda n: f"{uuid.uuid4().hex}%03d" % n)

--- a/manage_breast_screening/notifications/tests/factories.py
+++ b/manage_breast_screening/notifications/tests/factories.py
@@ -1,3 +1,4 @@
+import secrets
 import uuid
 from datetime import datetime, timedelta
 
@@ -69,3 +70,15 @@ class ChannelStatusFactory(DjangoModelFactory):
     message = SubFactory(MessageFactory)
     status = "read"
     status_updated_at = datetime.now() - timedelta(minutes=10)
+    idempotency_key = Sequence(lambda n: f"{secrets.token_hex(18)}%09d" % n)
+
+
+class MessageStatusFactory(DjangoModelFactory):
+    class Meta:
+        model = models.MessageStatus
+
+    description = "Delivered"
+    message = SubFactory(MessageFactory)
+    status = "delivered"
+    status_updated_at = datetime.now() - timedelta(minutes=10)
+    idempotency_key = Sequence(lambda n: f"{secrets.token_hex(18)}%09d" % n)

--- a/manage_breast_screening/notifications/tests/queries/test_failures.py
+++ b/manage_breast_screening/notifications/tests/queries/test_failures.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timedelta
+from random import randrange
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from manage_breast_screening.notifications.queries.failures import Failures
+from manage_breast_screening.notifications.tests.factories import (
+    AppointmentFactory,
+    MessageFactory,
+    MessageStatusFactory,
+)
+
+
+class TestFailures:
+    def create_message_set(
+        self,
+        date: datetime,
+        nhs_number: str,
+        episode_type: str,
+        status: str,
+        description: str,
+    ):
+        appt = AppointmentFactory(
+            starts_at=date, nhs_number=nhs_number, episode_type=episode_type
+        )
+        message = MessageFactory(appointment=appt)
+        MessageStatusFactory(message=message, status=status, description=description)
+        return appt
+
+    @pytest.mark.django_db
+    def test_failures_query_data_today(self):
+        def is_today(date_and_time: datetime) -> bool:
+            return date_and_time.strftime("%Y-%m-%d") == datetime.today().strftime(
+                "%Y-%m-%d"
+            )
+
+        def sometime_today():
+            now = datetime.today()
+            today = now.replace(hour=0, minute=0, tzinfo=ZoneInfo("Europe/London"))
+            return today + timedelta(hours=randrange(24), minutes=randrange(60))
+
+        appt1 = self.create_message_set(
+            sometime_today(),
+            "9990001111",
+            "S",
+            "failed",
+            "No reachable communication channel",
+        )
+        appt2 = self.create_message_set(
+            sometime_today(), "9990001112", "F", "failed", "Patient has an exit code"
+        )
+        appt3 = self.create_message_set(
+            sometime_today(), "9990001113", "R", "failed", "Patient is formally dead"
+        )
+        appt4 = self.create_message_set(
+            sometime_today(), "9990001114", "R", "failed", "Patient is informally dead"
+        )
+        appt5 = self.create_message_set(
+            sometime_today(),
+            "9990001115",
+            "S",
+            "failed",
+            "No reachable communication channel",
+        )
+
+        self.create_message_set(
+            sometime_today(), "9990001116", "S", "delivered", "Delivered"
+        )
+        self.create_message_set(
+            sometime_today() - timedelta(days=2),
+            "9990001117",
+            "S",
+            "failed",
+            "No reachable communication channel",
+        )
+
+        results = Failures().query().all()
+
+        assert len(results) == 5
+
+        assert results[0]["nhs_number"] == 9990001111
+        assert results[0]["appointment_date"] == appt1.starts_at
+        assert results[0]["episode_type"] == appt1.episode_type
+        assert results[0]["clinic_code"] == appt1.clinic.code
+        assert is_today(results[0]["failure_date"])
+        assert results[0]["failure_reason"] == "No reachable communication channel"
+
+        assert results[1]["nhs_number"] == 9990001112
+        assert results[1]["appointment_date"] == appt2.starts_at
+        assert results[1]["episode_type"] == appt2.episode_type
+        assert results[1]["clinic_code"] == appt2.clinic.code
+        assert is_today(results[1]["failure_date"])
+        assert results[1]["failure_reason"] == "Patient has an exit code"
+
+        assert results[2]["nhs_number"] == 9990001113
+        assert results[2]["appointment_date"] == appt3.starts_at
+        assert results[2]["episode_type"] == appt3.episode_type
+        assert results[2]["clinic_code"] == appt3.clinic.code
+        assert is_today(results[2]["failure_date"])
+        assert results[2]["failure_reason"] == "Patient is formally dead"
+
+        assert results[3]["nhs_number"] == 9990001114
+        assert results[3]["appointment_date"] == appt4.starts_at
+        assert results[3]["episode_type"] == appt4.episode_type
+        assert results[3]["clinic_code"] == appt4.clinic.code
+        assert is_today(results[3]["failure_date"])
+        assert results[3]["failure_reason"] == "Patient is informally dead"
+
+        assert results[4]["nhs_number"] == 9990001115
+        assert results[4]["appointment_date"] == appt5.starts_at
+        assert results[4]["episode_type"] == appt5.episode_type
+        assert results[4]["clinic_code"] == appt5.clinic.code
+        assert is_today(results[4]["failure_date"])
+        assert results[4]["failure_reason"] == "No reachable communication channel"
+
+    @pytest.mark.django_db
+    def test_failures_query_for_given_date(self):
+        the_date = datetime.today() - timedelta(days=2)
+
+        self.create_message_set(
+            the_date, "9990001111", "S", "failed", "No reachable communication channel"
+        )
+        self.create_message_set(
+            the_date - timedelta(days=1),
+            "9990001112",
+            "R",
+            "failed",
+            "No reachable communication channel",
+        )
+
+        results = Failures().query(the_date)
+
+        assert len(results) == 1
+        assert results[0]["nhs_number"] == 9990001111


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Adds a query class for the Private Beta failures report which returns a `django.db.QuerySet` instance. The queryset can be executed or turned into raw SQL as needed. 
This query can be used by the `pandas` library to generate CSV output via a `pandas.DataFrame` including any date/string transformations and formatting.

The query defaults to returning data from today, although a `datetime` can be passed in order to query data for a specific day. We could extend this to a weekly date range easily if necessary.

<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10660

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
