### PR TITLE
Feat/dtoss 10667 fix workflow attempting to deploy review environment after pr merge

### DIFF
--- a/.github/workflows/cicd-2-main-branch.yaml
+++ b/.github/workflows/cicd-2-main-branch.yaml
@@ -85,6 +85,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/stage-4-deploy.yaml
     with:
-      environments: '["review","dev"]'
+      environments: '["dev"]'
       commit_sha: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/stage-4-deploy.yaml
+++ b/.github/workflows/stage-4-deploy.yaml
@@ -38,6 +38,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Call deployment pipeline
+        if: ${{ inputs.pr_number && inputs.pr_number != '' }}
         run: |
           echo "Starting Azure devops pipeline \"Deploy to Azure - ${{ matrix.environment }}\"..."
           RUN_ID=$(az pipelines run \

--- a/infrastructure/environments/review/variables.tfvars
+++ b/infrastructure/environments/review/variables.tfvars
@@ -7,3 +7,4 @@ postgres_geo_redundant_backup_enabled = false
 protect_keyvault                      = false
 vnet_address_space                    = "10.142.0.0/16"
 personas_enabled                      = true
+postgres_prevent_destroy              = false

--- a/infrastructure/modules/container-apps/postgres.tf
+++ b/infrastructure/modules/container-apps/postgres.tf
@@ -5,6 +5,15 @@ data "azurerm_private_dns_zone" "postgres" {
   resource_group_name = "rg-hub-${var.hub}-uks-private-dns-zones"
 }
 
+resource "azurerm_management_lock" "postgres_lock" {
+  count = var.postgres_prevent_destroy ? 1 : 0
+
+  name       = "lock-${module.postgres.database_names[0]}"
+  scope      = module.postgres.id
+  lock_level = "CanNotDelete"
+  notes      = "Lock applied to prevent accidental deletion of Postgres server."
+}
+
 module "postgres" {
   source = "../dtos-devops-templates/infrastructure/modules/postgresql-flexible"
 
@@ -26,9 +35,9 @@ module "postgres" {
   monitor_diagnostic_setting_postgresql_server_enabled_logs = ["PostgreSQLLogs", "PostgreSQLFlexSessions", "PostgreSQLFlexQueryStoreRuntime", "PostgreSQLFlexQueryStoreWaitStats", "PostgreSQLFlexTableStats", "PostgreSQLFlexDatabaseXacts"]
   monitor_diagnostic_setting_postgresql_server_metrics      = ["AllMetrics"]
 
-  sku_name     = var.postgres_sku_name
-  storage_mb   = var.postgres_storage_mb
-  storage_tier = var.postgres_storage_tier
+  sku_name        = var.postgres_sku_name
+  storage_mb      = var.postgres_storage_mb
+  storage_tier    = var.postgres_storage_tier
 
   server_version = "16"
   tenant_id      = data.azurerm_client_config.current.tenant_id

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -72,6 +72,12 @@ variable "postgres_backup_retention_days" {
   type        = number
 }
 
+variable "postgres_prevent_destroy" {
+  type        = bool
+  default     = true
+  description = "If true, prevents the PostgreSQL flexible server from being destroyed."
+}
+
 variable "postgres_geo_redundant_backup_enabled" {
   description = "Whether geo-redundant backup is enabled for the PostgreSQL Flexible Server."
   type        = bool

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -51,6 +51,7 @@ module "container-apps" {
   log_analytics_workspace_audit_id      = var.deploy_infra ? module.infra[0].log_analytics_workspace_audit_id : data.azurerm_log_analytics_workspace.audit[0].id
   postgres_backup_retention_days        = var.postgres_backup_retention_days
   postgres_geo_redundant_backup_enabled = var.postgres_geo_redundant_backup_enabled
+  postgres_prevent_destroy              = var.postgres_prevent_destroy
   postgres_sku_name                     = var.postgres_sku_name
   postgres_sql_admin_group              = "postgres_${var.app_short_name}_${var.env_config}_uks_admin"
   postgres_storage_mb                   = var.postgres_storage_mb

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -72,6 +72,12 @@ variable "postgres_geo_redundant_backup_enabled" {
   default     = true
 }
 
+variable "postgres_prevent_destroy" {
+  type        = bool
+  default     = true
+  description = "If true, prevents the PostgreSQL flexible server from being destroyed."
+}
+
 variable "postgres_sku_name" {
   description = "Value of the PostgreSQL Flexible Server SKU name"
   default     = "B_Standard_B1ms"


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

This PR creates an optional resource lock on the postgres database which will avoid it being accidentally deleted. It also adds in functionality which avoids a review app being generated when the feature branch is merged into main, this essentially was trying to create an environment using a PR name which no longer exists. 

https://github.com/NHSDigital/dtos-manage-breast-screening/actions/runs/17152250710

The logic behind adding the resource lock is to remove the "life cycle" prevent delete from the template module as it was causing the deletion of the review app environments to not work. This change has already been merged into the template repo here: - 

https://github.com/NHSDigital/dtos-devops-templates/commit/d98d1e57fe0e60de0b47aa24c461dff2efa88c5b


<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10667

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10668
## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
