### PR TITLE
[DTOSS-10700] use a docker image for the postgres database for the review apps testing

### DIFF
--- a/infrastructure/environments/dev/variables.tfvars
+++ b/infrastructure/environments/dev/variables.tfvars
@@ -7,3 +7,4 @@ postgres_geo_redundant_backup_enabled = false
 protect_keyvault                      = false
 vnet_address_space                    = "10.128.0.0/16"
 personas_enabled                      = true
+seed_demo_data                        = true

--- a/infrastructure/environments/review/variables.tfvars
+++ b/infrastructure/environments/review/variables.tfvars
@@ -7,3 +7,5 @@ postgres_geo_redundant_backup_enabled = false
 protect_keyvault                      = false
 vnet_address_space                    = "10.142.0.0/16"
 personas_enabled                      = true
+deploy_database_as_container          = true
+seed_demo_data                        = true

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -42,6 +42,7 @@ module "container-apps" {
   default_domain                        = var.deploy_infra ? module.infra[0].default_domain : data.azurerm_container_app_environment.this[0].default_domain
   dns_zone_name                         = var.dns_zone_name
   docker_image                          = var.docker_image
+  deploy_database_as_container          = var.deploy_database_as_container
   enable_auth                           = var.enable_auth
   environment                           = var.environment
   env_config                            = var.env_config
@@ -56,5 +57,6 @@ module "container-apps" {
   postgres_storage_mb                   = var.postgres_storage_mb
   postgres_storage_tier                 = var.postgres_storage_tier
   postgres_subnet_id                    = var.deploy_infra ? module.infra[0].postgres_subnet_id : data.azurerm_subnet.postgres[0].id
+  seed_demo_data                        = var.seed_demo_data
   use_apex_domain                       = var.use_apex_domain
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -72,6 +72,12 @@ variable "postgres_geo_redundant_backup_enabled" {
   default     = true
 }
 
+variable "deploy_database_as_container" {
+  description = "Whether to deploy the database as a container or as an Azure postgres flexible server."
+  type        = bool
+  default     = false
+}
+
 variable "postgres_sku_name" {
   description = "Value of the PostgreSQL Flexible Server SKU name"
   default     = "B_Standard_B1ms"
@@ -112,6 +118,12 @@ variable "front_door_profile" {
 
 variable "personas_enabled" {
   description = "To enable personas or not."
+  type        = bool
+  default     = false
+}
+
+variable "seed_demo_data" {
+  description = "Whether or not to seed the demo data in the database."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

This PR introduces support for running the database as a Docker container instead of using an Azure-managed database.

**Database as container**
Adds configuration to run PostgreSQL as a container rather than relying solely on Azure Database for PostgreSQL.

**Seed demo data**
Parameterises seed_demo_data as a variable, allowing optional creation of demo seed data in the database.

**Random password management**
Generates a random password for the containerised PostgreSQL database.

Stores the password as a secret in:

- the WebApp Container App
- the Database Container App
- the Database Setup Container App job


<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10700

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->

## Testing / Validation

In file **infrastructure/environments/\<environment\>/variables.tfvars** update variable **deploy_database_as_container** and **seed_demo_data** to have values of true (which under environment **review**) should already be true. 

Parameter **deploy_database_as_container** when true will deploy the database as a container app using image "postgres:16".

This can be validated via seeing container app manbrs-db-\<pr number\>  (manbrs-db-pr-338)

<img width="1213" height="498" alt="image" src="https://github.com/user-attachments/assets/89f9d164-965b-4ddb-a93c-962d07ff28a9" />


Parameter **seed_demo_data** when true run command **"python manage.py migrate && python manage.py seed_demo_data --noinput"**; however, when false will run command **"python manage.py migrate"**. 

This can be validated editing the container in the container app job (seen below) and checking the "arguements override" which should be "python manage.py migrate && python manage.py seed_demo_data --noinput"


<img width="1372" height="957" alt="image" src="https://github.com/user-attachments/assets/f58c58a8-edf7-4b61-9b26-006eb636b53c" />



