### PR TITLE
Fix pipeline review dev

### DIFF
--- a/.azuredevops/pipelines/deploy.yml
+++ b/.azuredevops/pipelines/deploy.yml
@@ -57,4 +57,4 @@ stages:
                     scriptType: bash
                     scriptLocation: inlineScript
                     addSpnToEnvironment: true
-                    inlineScript: ./scripts/bash/db_run_job.sh ${{ parameters.environment }} ${{ parameters.prNumber }}
+                    inlineScript: make ci ${{ parameters.environment }} db-setup PR_NUMBER=${{ parameters.prNumber }}

--- a/.github/workflows/cicd-2-main-branch.yaml
+++ b/.github/workflows/cicd-2-main-branch.yaml
@@ -2,7 +2,7 @@ name: 'CI/CD main branch'
 
 on:
   push:
-    branches: [fix-pipeline-review-dev]
+    branches: [main]
 
 jobs:
   metadata:
@@ -33,9 +33,54 @@ jobs:
           echo "terraform_version=$(grep "^terraform" .tool-versions | cut -f2 -d' ')" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF}"
 
+  # Scan the commit
+  commit-stage:
+    name: 'Commit stage'
+    needs: [metadata]
+    uses: ./.github/workflows/stage-1-commit.yaml
+    with:
+      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
+      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
+      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
+      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
+      python_version: '${{ needs.metadata.outputs.python_version }}'
+      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
+      version: '${{ needs.metadata.outputs.version }}'
+    secrets: inherit
+
+  # Test the integrated code
+  test-stage:
+    name: 'Test stage'
+    needs: [metadata]
+    uses: ./.github/workflows/stage-2-test.yaml
+    with:
+      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
+      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
+      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
+      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
+      python_version: '${{ needs.metadata.outputs.python_version }}'
+      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
+      version: '${{ needs.metadata.outputs.version }}'
+    secrets: inherit
+
+  # Build the final artefact with the integrated code
+  build-stage: # Recommended maximum execution time is 3 minutes
+    name: 'Build stage'
+    needs: [metadata, commit-stage, test-stage]
+    uses: ./.github/workflows/stage-3-build.yaml
+    with:
+      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
+      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
+      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
+      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
+      python_version: '${{ needs.metadata.outputs.python_version }}'
+      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
+      version: '${{ needs.metadata.outputs.version }}'
+    secrets: inherit
+
   deploy-stage:
     name: Deploy stage
-    needs: [metadata]
+    needs: [build-stage]
     permissions:
       id-token: write
     uses: ./.github/workflows/stage-4-deploy.yaml

--- a/.github/workflows/cicd-2-main-branch.yaml
+++ b/.github/workflows/cicd-2-main-branch.yaml
@@ -2,7 +2,7 @@ name: 'CI/CD main branch'
 
 on:
   push:
-    branches: [main]
+    branches: [fix-pipeline-review-dev]
 
 jobs:
   metadata:
@@ -33,58 +33,13 @@ jobs:
           echo "terraform_version=$(grep "^terraform" .tool-versions | cut -f2 -d' ')" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF}"
 
-  # Scan the commit
-  commit-stage:
-    name: 'Commit stage'
-    needs: [metadata]
-    uses: ./.github/workflows/stage-1-commit.yaml
-    with:
-      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
-      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
-      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
-      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
-      python_version: '${{ needs.metadata.outputs.python_version }}'
-      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
-      version: '${{ needs.metadata.outputs.version }}'
-    secrets: inherit
-
-  # Test the integrated code
-  test-stage:
-    name: 'Test stage'
-    needs: [metadata]
-    uses: ./.github/workflows/stage-2-test.yaml
-    with:
-      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
-      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
-      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
-      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
-      python_version: '${{ needs.metadata.outputs.python_version }}'
-      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
-      version: '${{ needs.metadata.outputs.version }}'
-    secrets: inherit
-
-  # Build the final artefact with the integrated code
-  build-stage: # Recommended maximum execution time is 3 minutes
-    name: 'Build stage'
-    needs: [metadata, commit-stage, test-stage]
-    uses: ./.github/workflows/stage-3-build.yaml
-    with:
-      build_datetime: '${{ needs.metadata.outputs.build_datetime }}'
-      build_timestamp: '${{ needs.metadata.outputs.build_timestamp }}'
-      build_epoch: '${{ needs.metadata.outputs.build_epoch }}'
-      nodejs_version: '${{ needs.metadata.outputs.nodejs_version }}'
-      python_version: '${{ needs.metadata.outputs.python_version }}'
-      terraform_version: '${{ needs.metadata.outputs.terraform_version }}'
-      version: '${{ needs.metadata.outputs.version }}'
-    secrets: inherit
-
   deploy-stage:
     name: Deploy stage
-    needs: [build-stage]
+    needs: [metadata]
     permissions:
       id-token: write
     uses: ./.github/workflows/stage-4-deploy.yaml
     with:
-      environments: '["dev"]'
+      environments: '["review","dev"]'
       commit_sha: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/stage-4-deploy.yaml
+++ b/.github/workflows/stage-4-deploy.yaml
@@ -38,15 +38,20 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Call deployment pipeline
-        if: ${{ inputs.pr_number && inputs.pr_number != '' }}
         run: |
+          if [[ -n "${{inputs.pr_number}}" ]]; then
+            pr_argument="prNumber=${{inputs.pr_number}}"
+          else
+            pr_argument=""
+          fi
+
           echo "Starting Azure devops pipeline \"Deploy to Azure - ${{ matrix.environment }}\"..."
           RUN_ID=$(az pipelines run \
             --commit-id ${{inputs.commit_sha}} \
             --name "Deploy to Azure - ${{ matrix.environment }}" \
             --org https://dev.azure.com/nhse-dtos \
             --project dtos-manage-breast-screening \
-            --parameters commitSHA=${{inputs.commit_sha}} prNumber=${{inputs.pr_number}} environment=${{ matrix.environment }} \
+            --parameters commitSHA=${{inputs.commit_sha}} ${pr_argument} environment=${{ matrix.environment }} \
             --output tsv --query id)
 
           scripts/bash/wait_ado_pipeline.sh "$RUN_ID" https://dev.azure.com/nhse-dtos dtos-manage-breast-screening

--- a/infrastructure/environments/review/variables.tfvars
+++ b/infrastructure/environments/review/variables.tfvars
@@ -7,4 +7,3 @@ postgres_geo_redundant_backup_enabled = false
 protect_keyvault                      = false
 vnet_address_space                    = "10.142.0.0/16"
 personas_enabled                      = true
-postgres_prevent_destroy              = false

--- a/infrastructure/modules/container-apps/postgres.tf
+++ b/infrastructure/modules/container-apps/postgres.tf
@@ -5,15 +5,6 @@ data "azurerm_private_dns_zone" "postgres" {
   resource_group_name = "rg-hub-${var.hub}-uks-private-dns-zones"
 }
 
-resource "azurerm_management_lock" "postgres_lock" {
-  count = var.postgres_prevent_destroy ? 1 : 0
-
-  name       = "lock-${module.postgres.database_names[0]}"
-  scope      = module.postgres.id
-  lock_level = "CanNotDelete"
-  notes      = "Lock applied to prevent accidental deletion of Postgres server."
-}
-
 module "postgres" {
   source = "../dtos-devops-templates/infrastructure/modules/postgresql-flexible"
 
@@ -35,9 +26,9 @@ module "postgres" {
   monitor_diagnostic_setting_postgresql_server_enabled_logs = ["PostgreSQLLogs", "PostgreSQLFlexSessions", "PostgreSQLFlexQueryStoreRuntime", "PostgreSQLFlexQueryStoreWaitStats", "PostgreSQLFlexTableStats", "PostgreSQLFlexDatabaseXacts"]
   monitor_diagnostic_setting_postgresql_server_metrics      = ["AllMetrics"]
 
-  sku_name        = var.postgres_sku_name
-  storage_mb      = var.postgres_storage_mb
-  storage_tier    = var.postgres_storage_tier
+  sku_name     = var.postgres_sku_name
+  storage_mb   = var.postgres_storage_mb
+  storage_tier = var.postgres_storage_tier
 
   server_version = "16"
   tenant_id      = data.azurerm_client_config.current.tenant_id

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -72,12 +72,6 @@ variable "postgres_backup_retention_days" {
   type        = number
 }
 
-variable "postgres_prevent_destroy" {
-  type        = bool
-  default     = true
-  description = "If true, prevents the PostgreSQL flexible server from being destroyed."
-}
-
 variable "postgres_geo_redundant_backup_enabled" {
   description = "Whether geo-redundant backup is enabled for the PostgreSQL Flexible Server."
   type        = bool

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -51,7 +51,6 @@ module "container-apps" {
   log_analytics_workspace_audit_id      = var.deploy_infra ? module.infra[0].log_analytics_workspace_audit_id : data.azurerm_log_analytics_workspace.audit[0].id
   postgres_backup_retention_days        = var.postgres_backup_retention_days
   postgres_geo_redundant_backup_enabled = var.postgres_geo_redundant_backup_enabled
-  postgres_prevent_destroy              = var.postgres_prevent_destroy
   postgres_sku_name                     = var.postgres_sku_name
   postgres_sql_admin_group              = "postgres_${var.app_short_name}_${var.env_config}_uks_admin"
   postgres_storage_mb                   = var.postgres_storage_mb

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -72,12 +72,6 @@ variable "postgres_geo_redundant_backup_enabled" {
   default     = true
 }
 
-variable "postgres_prevent_destroy" {
-  type        = bool
-  default     = true
-  description = "If true, prevents the PostgreSQL flexible server from being destroyed."
-}
-
 variable "postgres_sku_name" {
   description = "Value of the PostgreSQL Flexible Server SKU name"
   default     = "B_Standard_B1ms"

--- a/scripts/bash/wait_ado_pipeline.sh
+++ b/scripts/bash/wait_ado_pipeline.sh
@@ -7,7 +7,7 @@ ORG_URL="$2"
 PROJECT="$3"
 
 SLEEP_TIME=15
-TIMEOUT_SECONDS=300
+TIMEOUT_SECONDS=3600
 
 echo "Waiting for Azure DevOps pipeline run $RUN_ID to complete..."
 

--- a/scripts/terraform/terraform.mk
+++ b/scripts/terraform/terraform.mk
@@ -11,6 +11,9 @@ review: # Target the review infrastructure, or a review app if PR_NUMBER is used
 	$(if ${PR_NUMBER}, $(eval export TF_VAR_deploy_infra=false), $(eval export TF_VAR_deploy_container_apps=false))
 	$(if ${PR_NUMBER}, $(eval export ENVIRONMENT=pr-${PR_NUMBER}), $(eval export ENVIRONMENT=review))
 
+db-setup:
+	$(if ${TF_VAR_deploy_container_apps},, scripts/bash/db_run_job.sh ${ENVIRONMENT} ${PR_NUMBER})
+
 ci: # Skip manual approvals when running in CI - make ci <env> <action>
 	$(eval AUTO_APPROVE=-auto-approve)
 	$(eval SKIP_AZURE_LOGIN=true)


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Varies changes in this PR: -

- Increase the github action workflow timeout for the ADO from 5 minutes to 1 hour
- Remove the azurerm_management_lock resource lock on the database as its better managed when its manually added to the database and outside of IAC.
- Allow github action workflow to be able to "Call deployment pipeline" when it does not have a PR_Number associated with it, this is to allow the merge to main to rebuild the dev environment. 

<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
