### PR TITLE
Use `datetime.now(tz)` wherever possible

### DIFF
--- a/manage_breast_screening/notifications/management/commands/create_appointments.py
+++ b/manage_breast_screening/notifications/management/commands/create_appointments.py
@@ -31,9 +31,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "date_str",
             nargs="?",
-            default=datetime.today()
-            .replace(tzinfo=TZ_INFO)
-            .strftime(DIR_NAME_DATE_FORMAT),
+            default=datetime.now(tz=TZ_INFO).strftime(DIR_NAME_DATE_FORMAT),
             help="yyy-MM-dd formatted date reflecting the Azure storage directory",
         )
 

--- a/manage_breast_screening/notifications/management/commands/send_message_batch.py
+++ b/manage_breast_screening/notifications/management/commands/send_message_batch.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
             message_batch = MessageBatch.objects.create(
                 routing_plan_id=routing_plan_id,
-                scheduled_at=datetime.today().replace(tzinfo=TZ_INFO),
+                scheduled_at=datetime.now(tz=TZ_INFO),
                 status=MessageBatchStatusChoices.SCHEDULED.value,
             )
 

--- a/manage_breast_screening/notifications/tests/queries/test_aggregate_query.py
+++ b/manage_breast_screening/notifications/tests/queries/test_aggregate_query.py
@@ -37,15 +37,14 @@ class TestAggregateQuery:
         return appt
 
     def test_query_aggregates_appointments_and_cascade_counts(self):
+        now = datetime.now(tz=ZoneInfo("Europe/London"))
         clinic1 = ClinicFactory(code="BU001", bso_code="BSO1", name="BSU 1")
         clinic2 = ClinicFactory(code="BU002", bso_code="BSO2", name="BSU 2")
 
-        date1 = datetime.today() - timedelta(days=10)
-        date1.replace(tzinfo=ZoneInfo("Europe/London"))
+        date1 = now - timedelta(days=10)
         df1 = date1.strftime("%Y-%m-%d")
 
-        date2 = datetime.today() - timedelta(days=15)
-        date2.replace(tzinfo=ZoneInfo("Europe/London"))
+        date2 = now - timedelta(days=15)
         df2 = date2.strftime("%Y-%m-%d")
 
         nhsapp_read = {"nhsapp": "read"}


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Simplifies a few places where we called `datetime.today()` and then `datetime.replace(tzinfo=...)` to set the timezone.
Uses shorter `datetime.now(tz)` form.
<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
