### PR TITLE
Add BASE_URL env var to config

### DIFF
--- a/docs/cis2_auth.md
+++ b/docs/cis2_auth.md
@@ -43,6 +43,7 @@ The following settings in `manage_breast_screening/config/settings.py` provide t
 - **`CIS2_CLIENT_PRIVATE_KEY`** - RSA private key in PEM format for JWT signing (supports `\n` escaped newlines)
 - **`CIS2_CLIENT_PUBLIC_KEY`** - Corresponding RSA public key in PEM format (supports `\n` escaped newlines)
 - **`CIS2_SCOPES`** - OAuth scopes requested
+- **`BASE_URL`** - Base URL for building absolute URLs (specifically for OAuth callbacks)
 
 The private and public keys form a keypair used for the `private_key_jwt` client authentication method.
 

--- a/manage_breast_screening/auth/oauth.py
+++ b/manage_breast_screening/auth/oauth.py
@@ -5,6 +5,7 @@ from authlib.integrations.django_client import OAuth
 from authlib.jose import JsonWebKey
 from authlib.oauth2.rfc7523 import PrivateKeyJWT, private_key_jwt_sign
 from django.conf import settings
+from django.urls import reverse
 
 oauth = OAuth()
 
@@ -47,6 +48,14 @@ def get_cis2_client():
     )
 
     return client
+
+
+def cis2_redirect_uri():
+    """Return the redirect URI for the CIS2 callback."""
+    # Handle trailing slashes
+    base_url = settings.BASE_URL.rstrip("/") if settings.BASE_URL else ""
+    callback_path = reverse("auth:cis2_callback").rstrip("/")
+    return f"{base_url}{callback_path}"
 
 
 # Authlib's PrivateKeyJWT doesn't allow us to change the default exp value set in the JWT, so we

--- a/manage_breast_screening/auth/views.py
+++ b/manage_breast_screening/auth/views.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from .oauth import get_cis2_client, jwk_from_public_key
+from .oauth import cis2_redirect_uri, get_cis2_client, jwk_from_public_key
 from .services import InvalidLogoutToken, decode_logout_token
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def logout(request):
 def cis2_login(request):
     """Start the CIS2 OAuth2/OIDC authorization flow."""
     client = get_cis2_client()
-    redirect_uri = request.build_absolute_uri(reverse("auth:cis2_callback")).rstrip("/")
+    redirect_uri = cis2_redirect_uri()
     # The acr_values param determines which authentication options are available to the user
     # See https://digital.nhs.uk/services/care-identity-service/applications-and-services/cis2-authentication/guidance-for-developers/detailed-guidance/acr-values#acr-values
     return client.authorize_redirect(

--- a/manage_breast_screening/config/.env.tpl
+++ b/manage_breast_screening/config/.env.tpl
@@ -11,6 +11,9 @@ LOG_QUERIES=0
 CMAPI_CONSUMER_KEY=some-consumer
 PERSONAS_ENABLED=1
 
+# Set to FQDN in deployed environments
+BASE_URL=http://localhost:8000
+
 # CIS2 / Authlib
 CIS2_SERVER_METADATA_URL=changeme
 CIS2_CLIENT_ID=changeme

--- a/manage_breast_screening/config/settings.py
+++ b/manage_breast_screening/config/settings.py
@@ -272,3 +272,5 @@ CIS2_CLIENT_PUBLIC_KEY = (
     public_key_inline.replace("\\n", "\n") if public_key_inline else None
 )
 CIS2_SCOPES = "openid profile email nhsperson associatedorgs"
+
+BASE_URL = environ.get("BASE_URL")

--- a/manage_breast_screening/tests/system/system_test_setup.py
+++ b/manage_breast_screening/tests/system/system_test_setup.py
@@ -2,6 +2,7 @@ import os
 from collections import Counter
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test.client import Client
@@ -32,6 +33,7 @@ class SystemTestCase(StaticLiveServerTestCase):
         self.page = self.context.new_page()
         self.page.set_default_timeout(5000)
         self.axe = AxeAdapter(self.page)
+        settings.BASE_URL = self.live_server_url
 
     def tearDown(self):
         self.page.close()


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description
On deployed environments, we need to be able to access the base url of
our app in order to construct a redirect_uri to pass on to the CIS2 auth
service. Calling `request.build_absolute_uri` in the Django app gives us the
azurecontainerapps.io URI, whereas we need the public-facing FQDN.

Rather than rely on headers, in this commit we add an explicit BASE_URL
environment variable. This is more visible and easier to debug.

This:

- Should be set to http://locahost:8000 in development
- Should be set to the FQDN in deployed environments

In our system tests, we set BASE_URL to match the value of
live_server_url so that callbacks from our fake CIS2 client work
correctly.
<!-- Add screenshots if there are any UI updates. -->

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10892
## Review notes
na
<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
