### PR TITLE
Fix conditional statement for integration test job

### DIFF
--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -99,7 +99,7 @@ jobs:
 
   notifications-integration-test:
     needs: test
-    if: needs.test.outputs.notifications-changed
+    if: needs.test.outputs.notifications-changed == 'true'
     name: 'Notifications Integration Tests'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

https://github.com/NHSDigital/dtos-manage-breast-screening/pull/375 attempted to make integration tests a separate downstream job from unit tests because of timeouts.
However the conditional [here](https://github.com/NHSDigital/dtos-manage-breast-screening/pull/375/files#diff-3510967c7b78ce8f5dc041f5252da1aab8dd63ef3b872a9f5fa78235d60de03cR102) which controls whether we run the integration tests did not work as expected and integration tests are being run for any changes, not just those particular to the notifications app.
This PR amends the `if` statement so that it uses the output from the `test` job properly.

See https://github.com/NHSDigital/dtos-manage-breast-screening/actions/runs/17582614042 for job being skipped.

<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10856

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
