### PR TITLE
DTOSS-10944: remove CMAPI consumer api key

### DIFF
--- a/manage_breast_screening/config/.env.tpl
+++ b/manage_breast_screening/config/.env.tpl
@@ -8,7 +8,6 @@ DATABASE_USER=manage
 DATABASE_SSLMODE=allow
 DATABASE_HOST=localhost
 LOG_QUERIES=0
-CMAPI_CONSUMER_KEY=some-consumer
 PERSONAS_ENABLED=1
 
 # Set to FQDN in deployed environments

--- a/manage_breast_screening/notifications/services/api_client.py
+++ b/manage_breast_screening/notifications/services/api_client.py
@@ -10,7 +10,6 @@ from manage_breast_screening.notifications.models import Message, MessageBatch
 EXPIRES_IN_MINUTES = 5
 
 AUTHORIZATION_HEADER_NAME = "authorization"
-CONSUMER_KEY_NAME = "x-consumer-key"
 
 
 class OAuthError(Exception):
@@ -55,7 +54,6 @@ class ApiClient:
             "accept": "application/vnd.api+json",
             "x-correlation-id": str(uuid.uuid4()),
             AUTHORIZATION_HEADER_NAME: f"Bearer {self.bearer_token()}",
-            CONSUMER_KEY_NAME: os.getenv("CMAPI_CONSUMER_KEY"),
         }
 
     def bearer_token(self) -> str:

--- a/manage_breast_screening/notifications/tests/dependencies/notify_api_stub/app.py
+++ b/manage_breast_screening/notifications/tests/dependencies/notify_api_stub/app.py
@@ -77,8 +77,6 @@ def verify_headers_for_consumers(headers: dict) -> tuple[bool, str]:
     lc_headers = header_keys_to_lower(headers)
     if lc_headers.get("authorization") is None:
         return False, "Missing Authorization header"
-    if lc_headers.get("x-consumer-key") is None:
-        return False, "Missing Consumer key header"
 
     return True, ""
 

--- a/manage_breast_screening/notifications/tests/integration/test_api_client_can_call_notify_api.py
+++ b/manage_breast_screening/notifications/tests/integration/test_api_client_can_call_notify_api.py
@@ -22,7 +22,6 @@ class TestApiClient:
         monkeypatch.setenv("OAUTH_API_KEY", "a1b2c3d4")
         monkeypatch.setenv("OAUTH_API_KID", "test-1")
         monkeypatch.setenv("PRIVATE_KEY", "test-key")
-        monkeypatch.setenv("CMAPI_CONSUMER_KEY", "consumer-key")
 
     @pytest.fixture
     def routing_plan_id(self):

--- a/manage_breast_screening/notifications/tests/integration/test_retry_message_batches_from_queue.py
+++ b/manage_breast_screening/notifications/tests/integration/test_retry_message_batches_from_queue.py
@@ -30,7 +30,6 @@ class TestRetryMessageBatchesFromQueue:
         monkeypatch.setenv("OAUTH_API_KEY", "a1b2c3d4")
         monkeypatch.setenv("OAUTH_API_KID", "test-1")
         monkeypatch.setenv("PRIVATE_KEY", "test-key")
-        monkeypatch.setenv("CMAPI_CONSUMER_KEY", "consumer-key")
 
     @pytest.fixture
     def routing_plan_id(self):

--- a/manage_breast_screening/notifications/tests/integration/test_send_message_batches_for_episode_types.py
+++ b/manage_breast_screening/notifications/tests/integration/test_send_message_batches_for_episode_types.py
@@ -30,7 +30,6 @@ class TestSendMessageBatch:
         monkeypatch.setenv("OAUTH_API_KEY", "a1b2c3d4")
         monkeypatch.setenv("OAUTH_API_KID", "test-1")
         monkeypatch.setenv("PRIVATE_KEY", "test-key")
-        monkeypatch.setenv("CMAPI_CONSUMER_KEY", "consumer-key")
 
     @pytest.mark.django_db
     def test_message_batch_is_sent_for_all_routing_plans(

--- a/manage_breast_screening/notifications/tests/services/test_api_client.py
+++ b/manage_breast_screening/notifications/tests/services/test_api_client.py
@@ -29,7 +29,6 @@ class TestApiClient:
         monkeypatch.setenv("OAUTH_API_KEY", "a1b2c3d4")
         monkeypatch.setenv("OAUTH_API_KID", "test-1")
         monkeypatch.setenv("PRIVATE_KEY", "test-key")
-        monkeypatch.setenv("CMAPI_CONSUMER_KEY", "consumer-key")
 
     @pytest.mark.django_db
     def test_send_message_batch(self, mock_jwt_encode, routing_plan_id):
@@ -58,7 +57,6 @@ class TestApiClient:
             assert request.headers["Authorization"] == "Bearer 000111"
             assert request.headers["Content-Type"] == "application/vnd.api+json"
             assert request.headers["Accept"] == "application/vnd.api+json"
-            assert request.headers["X-Consumer-Key"] == "consumer-key"
 
             assert attributes["messageBatchReference"] == str(message_batch.id)
             assert attributes["routingPlanId"] == message_batch.routing_plan_id


### PR DESCRIPTION
This no longer needs to be sent in the headers of batch requests as it was used by [CMAPI](https://github.com/NHSDigital/dtos-communication-management)

We should now be calling NHS Notify direct.

[DTOSS-10944](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10944)

(NOTE: for integration tests to pass locally you need to re-build the notify-api-stub container)

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
