### PR TITLE
DTOSS-10753: Add clinic location data

### DIFF
--- a/manage_breast_screening/notifications/data/clinic_location_data.json
+++ b/manage_breast_screening/notifications/data/clinic_location_data.json
@@ -1,0 +1,134 @@
+[
+  {
+    "code": "MDSAL",
+    "bso_code": "MBD",
+    "location_description": "Rear of Anchor Meadow Health Centre",
+    "location_url": "https://www.google.com/maps/search/WS9+8AJ"
+  },
+  {
+    "code": "MDSAT",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B6+6QR"
+  },
+  {
+    "code": "MDSBL",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/WS3+3JP"
+  },
+  {
+    "code": "MDSBR",
+    "bso_code": "MBD",
+    "location_description": "Off of Silver Street",
+    "location_url": "https://www.google.com/maps/search/WS8+6DZ"
+  },
+  {
+    "code": "MDSCV",
+    "bso_code": "MBD",
+    "location_description": "Vehicular access off Wood Lane",
+    "location_url": "https://www.google.com/maps/search/B24+9FP"
+  },
+  {
+    "code": "MDSCH",
+    "bso_code": "MBD",
+    "location_description": "beside the Treatment Centre",
+    "location_url": "https://www.google.com/maps/search/B18+7QH"
+  },
+  {
+    "code": "MDSCW",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B64+7HA"
+  },
+  {
+    "code": "MDSDA",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/WS10+8SY"
+  },
+  {
+    "code": "MDSDD",
+    "bso_code": "MBD",
+    "location_description": "off Perry Common Road",
+    "location_url": "https://www.google.com/maps/search/B23+5DD"
+  },
+  {
+    "code": "MDSHH",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B36+8DT"
+  },
+  {
+    "code": "MDSMG",
+    "bso_code": "MBD",
+    "location_description": "past store entrance to the end of the car park on the left",
+    "location_url": "https://www.google.com/maps/search/B75+5BT"
+  },
+  {
+    "code": "MDSOL",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B69+4DE"
+  },
+  {
+    "code": "MDSQU",
+    "bso_code": "MBD",
+    "location_description": "off Queslett Road",
+    "location_url": "https://www.google.com/maps/search/B43+7HA"
+  },
+  {
+    "code": "MDSSY",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B8+3SG"
+  },
+  {
+    "code": "MDSYG",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B10+0HH"
+  },
+  {
+    "code": "MDSVH",
+    "bso_code": "MBD",
+    "location_description": "off Windmill Lane",
+    "location_url": "https://www.google.com/maps/search/B66+3PZ"
+  },
+  {
+    "code": "MDSSG",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/B23+6DJ"
+  },
+  {
+    "code": "MDSNP",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/DY4+8PX"
+  },
+  {
+    "code": "MDSWA",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/WS2+9BZ"
+  },
+  {
+    "code": "MDSSH",
+    "bso_code": "MBD",
+    "location_description": "parked close to the Ante-Natal Clinic",
+    "location_url": "https://www.google.com/maps/search/B71+4HJ"
+  },
+  {
+    "code": "MDSWE",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/WS10+7BD"
+  },
+  {
+    "code": "MDSWJ",
+    "bso_code": "MBD",
+    "location_description": "",
+    "location_url": "https://www.google.com/maps/search/WV13+1QG"
+  }
+]


### PR DESCRIPTION
the `location_description` and `location_url` will be used in the personalisation fields when sending out appointment invites - this JSON data can be used to cross reference with Clinic data on our db to get the values. This is a quick solution for private beta as a way to reference this data without having to interfere with any existing data or data sources.

<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10753

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
