### PR TITLE
DTOSS-10982: add storage data contributor roles to managed identity RBAC

### DIFF
--- a/infrastructure/terraform/resource_group_init/core.bicep
+++ b/infrastructure/terraform/resource_group_init/core.bicep
@@ -10,6 +10,8 @@ var roleID = {
   contributor: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
   kvSecretsUser: '4633458b-17de-408a-b874-0445c86b69e6'
   rbacAdmin: 'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
+  storageBlobDataContributor: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+  storageQueueDataContributor: '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
 }
 
 // Let the managed identity configure resources in the subscription
@@ -38,8 +40,8 @@ resource rbacAdminAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleID.rbacAdmin)
     principalId: miPrincipalId
-    condition: '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {${roleID.kvSecretsUser}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {${roleID.kvSecretsUser}}))'
+    condition: '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {${roleID.kvSecretsUser}, ${roleID.storageBlobDataContributor}, ${roleID.storageQueueDataContributor}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {${roleID.kvSecretsUser}, ${roleID.storageBlobDataContributor}, ${roleID.storageQueueDataContributor}}))'
     conditionVersion: '2.0'
-    description: '${miName} Role Based Access Control Administrator access to subscription. Only allows assigning the Key Vault Secrets User role.'
+    description: '${miName} Role Based Access Control Administrator access to subscription. Can assign Key Vault Secrets User, Storage Blob Data Contributor, and Storage Queue Data Contributor roles.'
   }
 }


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

This PR extends the managed identity's RBAC permissions to support Azure Storage operations by adding Storage Blob Data Contributor and Storage Queue Data Contributor roles.

Key Changes:

- Added Storage Blob Data Contributor and Storage Queue Data Contributor role definitions to the roleID variable
- Updated the RBAC Administrator role assignment condition to allow the managed identity to assign these storage roles to other Managed identities
- The managed identity can now delegate Key Vault Secrets User, Storage Blob Data Contributor, and Storage Queue Data Contributor roles while maintaining principle of least privilege

Technical Details:

- Uses Azure's conditional role assignment feature to constrain which roles can be assigned
- Maintains security by only allowing assignment of specific, predefined roles

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
