### PR TITLE
Connect to MESH using SSL

### DIFF
--- a/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
+++ b/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
@@ -32,9 +32,9 @@ class Command(BaseCommand):
 
     def mesh_client(self):
         client = MeshClient(
-            url=os.getenv("MESH_BASE_URL"),
-            mailbox=os.getenv("MESH_INBOX_NAME"),
-            password=os.getenv("MESH_CLIENT_PASSWORD"),
-            shared_key=os.getenv("MESH_CLIENT_SHARED_KEY"),
+            url=os.getenv("NBSS_MESH_HOST"),
+            mailbox=os.getenv("NBSS_MESH_INBOX_NAME"),
+            password=os.getenv("NBSS_MESH_PASSWORD"),
+            shared_key=os.getenv("NBSS_MESH_SHARED_KEY"),
         )
         return client

--- a/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
+++ b/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
@@ -1,10 +1,9 @@
-import os
 from datetime import datetime
 
 from django.core.management.base import BaseCommand, CommandError
-from mesh_client import MeshClient
 
 from manage_breast_screening.notifications.services.blob_storage import BlobStorage
+from manage_breast_screening.notifications.services.mesh_inbox import MeshInbox
 
 
 class Command(BaseCommand):
@@ -15,26 +14,17 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            with self.mesh_client() as client:
-                today_dirname = datetime.today().strftime("%Y-%m-%d")
-                for message in client.list_messages():
-                    appointment = client.retrieve_message(message)
+            today_dirname = datetime.today().strftime("%Y-%m-%d")
+            with MeshInbox() as inbox:
+                for message_id in inbox.fetch_message_ids():
+                    appointment = inbox.fetch_message(message_id)
 
                     BlobStorage().add(
                         f"{today_dirname}/{appointment.filename}",
                         appointment.read().decode("ASCII"),
                     )
 
-                    client.acknowledge_message(message)
+                    inbox.acknowledge(message_id)
 
         except Exception as e:
             raise CommandError(e)
-
-    def mesh_client(self):
-        client = MeshClient(
-            url=os.getenv("NBSS_MESH_HOST"),
-            mailbox=os.getenv("NBSS_MESH_INBOX_NAME"),
-            password=os.getenv("NBSS_MESH_PASSWORD"),
-            shared_key=os.getenv("NBSS_MESH_SHARED_KEY"),
-        )
-        return client

--- a/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
+++ b/manage_breast_screening/notifications/management/commands/store_mesh_messages.py
@@ -17,11 +17,11 @@ class Command(BaseCommand):
             today_dirname = datetime.today().strftime("%Y-%m-%d")
             with MeshInbox() as inbox:
                 for message_id in inbox.fetch_message_ids():
-                    appointment = inbox.fetch_message(message_id)
+                    message = inbox.fetch_message(message_id)
 
                     BlobStorage().add(
-                        f"{today_dirname}/{appointment.filename}",
-                        appointment.read().decode("ASCII"),
+                        f"{today_dirname}/{message.filename}",
+                        message.read().decode("ASCII"),
                     )
 
                     inbox.acknowledge(message_id)

--- a/manage_breast_screening/notifications/services/mesh_inbox.py
+++ b/manage_breast_screening/notifications/services/mesh_inbox.py
@@ -1,0 +1,52 @@
+import os
+from tempfile import NamedTemporaryFile
+
+from mesh_client import MeshClient, Message
+
+
+class MeshInbox:
+    def __init__(self):
+        cert_file, private_key_file, ca_cert_file = self.ssl_credentials()
+        self.client = MeshClient(
+            url=os.getenv("NBSS_MESH_HOST"),
+            mailbox=os.getenv("NBSS_MESH_INBOX_NAME"),
+            password=os.getenv("NBSS_MESH_PASSWORD"),
+            shared_key=os.getenv("NBSS_MESH_SHARED_KEY"),
+            cert=(cert_file, private_key_file),
+            verify=ca_cert_file,
+        )
+        self.client.handshake()
+
+    def fetch_message_ids(self) -> list[str]:
+        return self.client.list_messages()
+
+    def fetch_message(self, message_id: str) -> Message:
+        return self.client.retrieve_message(message_id)
+
+    def acknowledge(self, message_id: str):
+        self.client.acknowledge_message(message_id)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, tb):
+        self.client.close()
+
+    @classmethod
+    def ssl_credentials(cls) -> tuple[NamedTemporaryFile]:
+        cert = os.getenv("NBSS_MESH_CERT")
+        private_key = os.getenv("NBSS_MESH_PRIVATE_KEY")
+        ca_cert = os.getenv("NBSS_MESH_CA_CERT")
+
+        return (
+            cls.to_file(cert).name,
+            cls.to_file(private_key).name,
+            cls.to_file(ca_cert).name,
+        )
+
+    @staticmethod
+    def to_file(cert: str) -> NamedTemporaryFile:
+        file = NamedTemporaryFile(delete=False)
+        file.write(cert.encode("utf-8"))
+
+        return file

--- a/manage_breast_screening/notifications/tests/integration/helpers.py
+++ b/manage_breast_screening/notifications/tests/integration/helpers.py
@@ -18,7 +18,7 @@ class Helpers:
                 shared_key=os.getenv("NBSS_MESH_SHARED_KEY", "TestKey"),
             ) as client:
                 client.send_message(
-                    os.getenv("MESH_INBOX_NAME"),
+                    os.getenv("NBSS_MESH_INBOX_NAME"),
                     file.read().encode("ASCII"),
                     filename=os.path.basename(filepath),
                     workflow_id="TEST_NBSS_WORKFLOW",

--- a/manage_breast_screening/notifications/tests/integration/helpers.py
+++ b/manage_breast_screening/notifications/tests/integration/helpers.py
@@ -12,10 +12,10 @@ class Helpers:
         """Adds a file to MESH sandbox mailbox"""
         with open(filepath) as file:
             with MeshClient(
-                url=os.getenv("MESH_BASE_URL", "http://localhost:8700"),
-                mailbox=os.getenv("MESH_INBOX_NAME", "X26ABC1"),
-                password=os.getenv("MESH_CLIENT_PASSWORD", "password"),
-                shared_key=os.getenv("MESH_CLIENT_SHARED_KEY", "TestKey"),
+                url=os.getenv("NBSS_MESH_HOST", "http://localhost:8700"),
+                mailbox=os.getenv("NBSS_MESH_INBOX_NAME", "X26ABC1"),
+                password=os.getenv("NBSS_MESH_PASSWORD", "password"),
+                shared_key=os.getenv("NBSS_MESH_SHARED_KEY", "TestKey"),
             ) as client:
                 client.send_message(
                     os.getenv("MESH_INBOX_NAME"),

--- a/manage_breast_screening/notifications/tests/integration/test_mesh_client.py
+++ b/manage_breast_screening/notifications/tests/integration/test_mesh_client.py
@@ -10,10 +10,10 @@ from manage_breast_screening.notifications.tests.integration.helpers import Help
 class TestMeshClient:
     @pytest.fixture(autouse=True)
     def setup(self, monkeypatch):
-        monkeypatch.setenv("MESH_BASE_URL", "http://localhost:8700")
-        monkeypatch.setenv("MESH_CLIENT_PASSWORD", "password")
-        monkeypatch.setenv("MESH_CLIENT_SHARED_KEY", "TestKey")
-        monkeypatch.setenv("MESH_INBOX_NAME", "X26ABC1")
+        monkeypatch.setenv("NBSS_MESH_HOST", "http://localhost:8700")
+        monkeypatch.setenv("NBSS_MESH_PASSWORD", "password")
+        monkeypatch.setenv("NBSS_MESH_SHARED_KEY", "TestKey")
+        monkeypatch.setenv("NBSS_MESH_INBOX_NAME", "X26ABC1")
 
     @pytest.fixture
     def helpers(self):
@@ -24,10 +24,10 @@ class TestMeshClient:
         helpers.add_file_to_mesh_mailbox(test_file_path)
 
         with MeshClient(
-            url=os.getenv("MESH_BASE_URL"),
-            mailbox=os.getenv("MESH_INBOX_NAME"),
-            password=os.getenv("MESH_CLIENT_PASSWORD"),
-            shared_key=os.getenv("MESH_CLIENT_SHARED_KEY"),
+            url=os.getenv("NBSS_MESH_HOST"),
+            mailbox=os.getenv("NBSS_MESH_INBOX_NAME"),
+            password=os.getenv("NBSS_MESH_PASSWORD"),
+            shared_key=os.getenv("NBSS_MESH_SHARED_KEY"),
         ) as client:
             message_ids = client.list_messages()
 

--- a/manage_breast_screening/notifications/tests/integration/test_store_mesh_messages.py
+++ b/manage_breast_screening/notifications/tests/integration/test_store_mesh_messages.py
@@ -16,10 +16,10 @@ from manage_breast_screening.notifications.tests.integration.helpers import Help
 class TestStoreMeshMessages:
     @pytest.fixture(autouse=True)
     def setup(self, monkeypatch):
-        monkeypatch.setenv("MESH_BASE_URL", "http://localhost:8700")
-        monkeypatch.setenv("MESH_CLIENT_PASSWORD", "password")
-        monkeypatch.setenv("MESH_CLIENT_SHARED_KEY", "TestKey")
-        monkeypatch.setenv("MESH_INBOX_NAME", "X26ABC1")
+        monkeypatch.setenv("NBSS_MESH_HOST", "http://localhost:8700")
+        monkeypatch.setenv("NBSS_MESH_PASSWORD", "password")
+        monkeypatch.setenv("NBSS_MESH_SHARED_KEY", "TestKey")
+        monkeypatch.setenv("NBSS_MESH_INBOX_NAME", "X26ABC1")
 
         monkeypatch.setenv(
             "BLOB_STORAGE_CONNECTION_STRING", Helpers().azurite_connection_string()
@@ -37,10 +37,10 @@ class TestStoreMeshMessages:
         helpers.add_file_to_mesh_mailbox(test_file_2)
 
         with MeshClient(
-            url=os.getenv("MESH_BASE_URL"),
-            mailbox=os.getenv("MESH_INBOX_NAME"),
-            password=os.getenv("MESH_CLIENT_PASSWORD"),
-            shared_key=os.getenv("MESH_CLIENT_SHARED_KEY"),
+            url=os.getenv("NBSS_MESH_HOST"),
+            mailbox=os.getenv("NBSS_MESH_INBOX_NAME"),
+            password=os.getenv("NBSS_MESH_PASSWORD"),
+            shared_key=os.getenv("NBSS_MESH_SHARED_KEY"),
         ) as client:
             assert len(client.list_messages()) == 2
 

--- a/manage_breast_screening/notifications/tests/integration/test_store_mesh_messages.py
+++ b/manage_breast_screening/notifications/tests/integration/test_store_mesh_messages.py
@@ -20,6 +20,9 @@ class TestStoreMeshMessages:
         monkeypatch.setenv("NBSS_MESH_PASSWORD", "password")
         monkeypatch.setenv("NBSS_MESH_SHARED_KEY", "TestKey")
         monkeypatch.setenv("NBSS_MESH_INBOX_NAME", "X26ABC1")
+        monkeypatch.setenv("NBSS_MESH_CERT", "mesh-cert")
+        monkeypatch.setenv("NBSS_MESH_PRIVATE_KEY", "mesh-private-key")
+        monkeypatch.setenv("NBSS_MESH_CA_CERT", "mesh-ca-cert")
 
         monkeypatch.setenv(
             "BLOB_STORAGE_CONNECTION_STRING", Helpers().azurite_connection_string()

--- a/manage_breast_screening/notifications/tests/management/commands/test_store_mesh_messages.py
+++ b/manage_breast_screening/notifications/tests/management/commands/test_store_mesh_messages.py
@@ -1,0 +1,57 @@
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from manage_breast_screening.notifications.management.commands.store_mesh_messages import (
+    Command,
+)
+
+
+@patch(
+    "manage_breast_screening.notifications.management.commands.store_mesh_messages.BlobStorage"
+)
+@patch(
+    "manage_breast_screening.notifications.management.commands.store_mesh_messages.MeshInbox"
+)
+class TestStoreMeshMessages:
+    def test_handle_stores_blobs(self, mock_mesh_inbox, mock_blob_storage, monkeypatch):
+        dirname = datetime.datetime.now().strftime("%Y-%m-%d")
+        message1 = Mock()
+        message1.filename = "file1"
+        message1.read.return_value = "message1 content".encode("ASCII")
+        message2 = Mock()
+        message2.filename = "file2"
+        message2.read.return_value = "message2 content".encode("ASCII")
+
+        mock_inbox_context = mock_mesh_inbox.return_value.__enter__()
+
+        mock_inbox_context.fetch_message_ids.return_value = ["id1", "id2"]
+        mock_inbox_context.fetch_message.side_effect = [message1, message2]
+
+        Command().handle()
+
+        mock_inbox_context.acknowledge.assert_any_call("id1")
+        mock_inbox_context.acknowledge.assert_any_call("id2")
+
+        mock_blob_storage.return_value.add.assert_any_call(
+            f"{dirname}/file1", "message1 content"
+        )
+        mock_blob_storage.return_value.add.assert_any_call(
+            f"{dirname}/file2", "message2 content"
+        )
+
+    def test_handle_empty_inbox(self, mock_mesh_inbox, mock_blob_storage):
+        mock_mesh_inbox.return_value.__enter__().fetch_message_ids.return_value = []
+
+        Command().handle()
+
+        mock_mesh_inbox.return_value.__enter__().acknowledge.assert_not_called()
+        mock_blob_storage.return_value.add.assert_not_called()
+
+    def test_handle_raises_command_error(self, mock_mesh_inbox, _x):
+        mock_mesh_inbox.side_effect = Exception("Noooo!")
+
+        with pytest.raises(CommandError):
+            Command().handle()

--- a/manage_breast_screening/notifications/tests/services/test_mesh_inbox.py
+++ b/manage_breast_screening/notifications/tests/services/test_mesh_inbox.py
@@ -1,0 +1,90 @@
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from manage_breast_screening.notifications.services.mesh_inbox import MeshInbox
+
+
+@patch("manage_breast_screening.notifications.services.mesh_inbox.MeshClient")
+class TestMeshInbox:
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        monkeypatch.setenv("NBSS_MESH_HOST", "https://mesh.test")
+        monkeypatch.setenv("NBSS_MESH_INBOX_NAME", "mesh-inbox-name")
+        monkeypatch.setenv("NBSS_MESH_PASSWORD", "mesh-password")
+        monkeypatch.setenv("NBSS_MESH_SHARED_KEY", "mesh-shared-key")
+        monkeypatch.setenv("NBSS_MESH_CERT", "mesh-cert")
+        monkeypatch.setenv("NBSS_MESH_PRIVATE_KEY", "mesh-private-key")
+        monkeypatch.setenv("NBSS_MESH_CA_CERT", "mesh-ca-cert")
+
+    def test_client_initialises(self, mock_mesh_client):
+        with patch.object(
+            MeshInbox,
+            "ssl_credentials",
+            return_value=("cert", "private-key", "ca-cert"),
+        ):
+            MeshInbox()
+
+        mock_mesh_client.assert_called_once_with(
+            url="https://mesh.test",
+            mailbox="mesh-inbox-name",
+            password="mesh-password",
+            shared_key="mesh-shared-key",
+            cert=("cert", "private-key"),
+            verify="ca-cert",
+        )
+
+    def test_constructor_as_contextmanager(self, mock_mesh_client):
+        with MeshInbox() as inbox:
+            inbox.fetch_message_ids()
+
+        mock_mesh_client.assert_called_once_with(
+            url="https://mesh.test",
+            mailbox="mesh-inbox-name",
+            password="mesh-password",
+            shared_key="mesh-shared-key",
+            cert=(ANY, ANY),
+            verify=ANY,
+        )
+        mock_mesh_client.return_value.list_messages.assert_called_once()
+        mock_mesh_client.return_value.close.assert_called_once()
+
+    def test_ssl_credentials(self, _unused_mock):
+        mock_cert_file = MagicMock()
+        mock_cert_file.name = "cert"
+        mock_private_key_file = MagicMock()
+        mock_private_key_file.name = "private-key"
+        mock_ca_cert_file = MagicMock()
+        mock_ca_cert_file.name = "ca-cert"
+
+        with patch.object(
+            MeshInbox,
+            "to_file",
+            side_effect=[mock_cert_file, mock_private_key_file, mock_ca_cert_file],
+        ):
+            cert_file_name, private_key_file_name, ca_cert_file_name = (
+                MeshInbox.ssl_credentials()
+            )
+
+        assert cert_file_name == "cert"
+        assert private_key_file_name == "private-key"
+        assert ca_cert_file_name == "ca-cert"
+
+    def test_fetch_message_ids(self, mock_mesh_client):
+        MeshInbox().fetch_message_ids()
+
+        mock_mesh_client.return_value.list_messages.assert_called_once()
+
+    def test_fetch_message(self, mock_mesh_client):
+        MeshInbox().fetch_message("some-message-id")
+
+        mock_mesh_client.return_value.retrieve_message.assert_called_once_with(
+            "some-message-id"
+        )
+
+    def test_acknowledge(self, mock_mesh_client):
+        MeshInbox().acknowledge("a-message-id")
+
+        mock_mesh_client.return_value.acknowledge_message.assert_called_once_with(
+            "a-message-id"
+        )


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

In deployed environments we need to connect to a real MESH inbox using SSL.
This is done by providing certificates for verification.

This PR:
- Adds a `MeshInbox` service which handles reading certificate content from the environment (originating from Azure Keyvault).
- Adds unit test coverage for `store_mesh_messages` command.

<!-- Add screenshots if there are any UI updates. -->

## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10919

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
