### PR TITLE
[DTOSS-10724] show symptoms

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -43,3 +43,7 @@ a[href="#"] {
   right: 0;
   text-align: right;
 }
+
+p:has(+ .app-inset-text) {
+  margin-bottom: 0;
+}

--- a/manage_breast_screening/core/template_helpers.py
+++ b/manage_breast_screening/core/template_helpers.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from markupsafe import Markup, escape
 
 
-def no_wrap(value):
+def no_wrap(value: str) -> Markup:
     """
     Wrap a string in a span with class app-no-wrap
 
@@ -14,7 +14,7 @@ def no_wrap(value):
     )
 
 
-def nl2br(value):
+def nl2br(value: str) -> Markup:
     """
     Convert newline characters to html line breaks
 
@@ -28,7 +28,17 @@ def nl2br(value):
     return Markup("<br>".join([escape(line) for line in lines]))
 
 
-def as_hint(value):
+def multiline_content(lines: list[str]) -> Markup:
+    """
+    Convert a list of strings to html line breaks
+
+    >>> multiline_content(["first", "second", "third"])
+    Markup('first<br>second<br>third')
+    """
+    return nl2br("\n".join(lines))
+
+
+def as_hint(value: str) -> Markup:
     """
     Wrap a string in a span with class nhsuk-u-secondary-text-color
 

--- a/manage_breast_screening/core/utils/date_formatting.py
+++ b/manage_breast_screening/core/utils/date_formatting.py
@@ -71,6 +71,23 @@ def format_date_time(value):
     return f"{date_part}, {time_part}"
 
 
+def format_approximate_date(year, month):
+    """
+    Format an approximate date in the past
+    """
+    current = date.today().replace(day=1)
+    provided = date(year, month, 1)
+
+    if current == provided:
+        relative_part = "this month"
+    elif current < provided:
+        raise ValueError(f"{year=}, {month=} should be in the past")
+    else:
+        relative_part = f"{_format_date_difference(provided, current)} ago"
+
+    return provided.strftime("%B %Y" + f" ({relative_part})")
+
+
 def format_time(value):
     """
     Format a time on a 12-hour clock, with special cases for midday and midnight.

--- a/manage_breast_screening/core/utils/tests/test_date_formatting.py
+++ b/manage_breast_screening/core/utils/tests/test_date_formatting.py
@@ -4,7 +4,7 @@ from zoneinfo import ZoneInfo
 import pytest
 import time_machine
 
-from ..date_formatting import format_relative_date
+from ..date_formatting import format_approximate_date, format_relative_date
 
 
 @time_machine.travel(datetime(2025, 5, 2, 10, tzinfo=ZoneInfo("Europe/London")))
@@ -25,3 +25,43 @@ from ..date_formatting import format_relative_date
 )
 def test_relative_dates(dateiso, output):
     assert format_relative_date(datetime.fromisoformat(dateiso)) == output
+
+
+@pytest.mark.parametrize(
+    ("today", "year", "month", "output"),
+    (
+        (
+            datetime(2025, 5, 2, 10, tzinfo=ZoneInfo("Europe/London")),
+            2025,
+            1,
+            "January 2025 (4 months ago)",
+        ),
+        (
+            datetime(2025, 5, 2, 10, tzinfo=ZoneInfo("Europe/London")),
+            2025,
+            5,
+            "May 2025 (this month)",
+        ),
+        (
+            datetime(2025, 5, 2, 10, tzinfo=ZoneInfo("Europe/London")),
+            2024,
+            5,
+            "May 2024 (1 year ago)",
+        ),
+        (
+            datetime(2025, 5, 31, 10, tzinfo=ZoneInfo("Europe/London")),
+            2024,
+            4,
+            "April 2024 (1 year, 1 month ago)",
+        ),
+    ),
+)
+def test_approximate_dates(time_machine, today, year, month, output):
+    time_machine.move_to(today)
+    assert format_approximate_date(year, month) == output
+
+
+@time_machine.travel(datetime(2025, 5, 2, 10, tzinfo=ZoneInfo("Europe/London")))
+def test_approximate_future_date_raises_error():
+    with pytest.raises(ValueError):
+        format_approximate_date(3000, 1)

--- a/manage_breast_screening/data/east_tester_today_clinic_data.yml
+++ b/manage_breast_screening/data/east_tester_today_clinic_data.yml
@@ -86,6 +86,12 @@ clinic:
                 - 806 Clinic Road
                 - Leeds
               postcode: B2 7E9
+        symptoms:
+          - id: e9cc27f6-8e6f-4b83-890c-d73590c40f81
+            symptom_type_id: lump
+            area: RIGHT_BREAST
+            when_started: LESS_THAN_THREE_MONTHS
+
     - id: 309b6d74-7776-44e3-8ea7-9c5fd8e72a0b
       duration_in_minutes: 8
       starts_at_time: 09:24

--- a/manage_breast_screening/mammograms/admin.py
+++ b/manage_breast_screening/mammograms/admin.py
@@ -1,1 +1,0 @@
-# Register your models here.

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -15,7 +15,13 @@
         "rows": presenter.symptom_rows
       }) }}
   {% else %}
-    <p>No symptoms have been recorded for this participant.</p>
+    {% set insetHtml %}
+      <p>No symptoms have been recorded for this participant.</p>
+    {% endset %}
+    {{ insetText({
+      "html": insetHtml,
+      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4 app-inset-text"
+    }) }}
   {% endif %}
 
   <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
@@ -85,7 +91,7 @@
     {% endset %}
     {{ insetText({
       "html": insetHtml,
-      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4"
+      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4 app-inset-text"
     }) }}
 
     <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -7,7 +7,6 @@
 
 {% call card({
   "heading": "Symptoms",
-  "headingLevel": "2",
 }) %}
   <p>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
   {% if presenter.symptom_rows %}
@@ -79,7 +78,6 @@
 {% endset %}
 {{ card({
   "heading": "Medical history",
-  "headingLevel": "2",
   "descriptionHtml": medical_history_card_html
 }) }}
 
@@ -100,7 +98,6 @@
 {% endset %}
 {{ card({
   "heading": "Breast features",
-  "headingLevel": "2",
   "descriptionHtml": breast_features_card_html
 }) }}
 
@@ -114,7 +111,6 @@
 {% endset %}
 {{ card({
   "heading": "Other information",
-  "headingLevel": "2",
   "descriptionHtml": other_information_card_html
 }) }}
 

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -5,26 +5,23 @@
 
 {% block step_content %}
 
-{% set symptoms_card_html %}
-    {% set has_symptoms = false %}
-
-    {% set inset_html %}
-    <p>No symptoms have been recorded for this participant.</p>
-    {% endset %}
-    {{ insetText({
-      "html": inset_html,
-      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4"
-    }) }}
-
-    <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
-      <a href="#" class="nhsuk-link">{{ "Add another symptom" if has_symptoms else "Add a symptom" }}</a>
-    </p>
-{% endset %}
-{{ card({
-  "heading": "Recent breast changes or symptoms",
+{% call card({
+  "heading": "Symptoms",
   "headingLevel": "2",
-  "descriptionHtml": symptoms_card_html
-}) }}
+}) %}
+  <p>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
+  {% if presenter.symptom_rows %}
+    {{ summaryList({
+      "rows": presenter.symptom_rows
+    }) }}
+  {% else %}
+    <p>No symptoms have been recorded for this participant.</p>
+  {% endif %}
+
+  <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
+    <a href="#" class="nhsuk-link">{{ "Add another symptom" if presenter.symptom_rows else "Add a symptom" }}</a>
+  </p>
+{% endcall %}
 
 {% set medical_history_card_html %}
   {% set breast_cancer_history_link %}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -11,9 +11,9 @@
 }) %}
   <p>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
   {% if presenter.symptom_rows %}
-    {{ summaryList({
-      "rows": presenter.symptom_rows
-    }) }}
+     {{ summaryList({
+        "rows": presenter.symptom_rows
+      }) }}
   {% else %}
     <p>No symptoms have been recorded for this participant.</p>
   {% endif %}

--- a/manage_breast_screening/mammograms/presenters/__init__.py
+++ b/manage_breast_screening/mammograms/presenters/__init__.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+
+from .appointment_presenters import (
+    AppointmentPresenter,
+    ClinicSlotPresenter,
+    SpecialAppointmentPresenter,
+)
+from .last_known_mammogram_presenter import LastKnownMammogramPresenter
+
+
+def present_secondary_nav(pk):
+    """
+    Build a secondary nav for reviewing the information of screened/partially screened appointments.
+    """
+    return [
+        {
+            "id": "all",
+            "text": "Appointment details",
+            "href": reverse("mammograms:show_appointment", kwargs={"pk": pk}),
+            "current": True,
+        },
+        {"id": "medical_information", "text": "Medical information", "href": "#"},
+        {"id": "images", "text": "Images", "href": "#"},
+    ]
+
+
+__all__ = [
+    "AppointmentPresenter",
+    "ClinicSlotPresenter",
+    "LastKnownMammogramPresenter",
+    "SpecialAppointmentPresenter",
+]

--- a/manage_breast_screening/mammograms/presenters/appointment_presenters.py
+++ b/manage_breast_screening/mammograms/presenters/appointment_presenters.py
@@ -2,25 +2,9 @@ from functools import cached_property
 
 from django.urls import reverse
 
-from ..core.utils.date_formatting import format_date, format_relative_date, format_time
-from ..participants.models import AppointmentStatus, SupportReasons
-from ..participants.presenters import ParticipantPresenter, status_colour
-
-
-def present_secondary_nav(pk):
-    """
-    Build a secondary nav for reviewing the information of screened/partially screened appointments.
-    """
-    return [
-        {
-            "id": "all",
-            "text": "Appointment details",
-            "href": reverse("mammograms:show_appointment", kwargs={"pk": pk}),
-            "current": True,
-        },
-        {"id": "medical_information", "text": "Medical information", "href": "#"},
-        {"id": "images", "text": "Images", "href": "#"},
-    ]
+from ...core.utils.date_formatting import format_date, format_relative_date, format_time
+from ...participants.models import AppointmentStatus, SupportReasons
+from ...participants.presenters import ParticipantPresenter, status_colour
 
 
 class AppointmentPresenter:
@@ -91,76 +75,6 @@ class AppointmentPresenter:
             "key": current_status.state,
             "is_confirmed": current_status.state == AppointmentStatus.CONFIRMED,
             "is_screened": current_status.state == AppointmentStatus.SCREENED,
-        }
-
-
-class LastKnownMammogramPresenter:
-    def __init__(self, last_known_mammograms, participant_pk, current_url):
-        self._last_known_mammograms = last_known_mammograms
-        self.participant_pk = participant_pk
-        self.current_url = current_url
-
-    @cached_property
-    def last_known_mammograms(self):
-        result = []
-        for mammogram in self._last_known_mammograms:
-            result.append(self._present_mammogram(mammogram))
-
-        return result
-
-    def _present_mammogram(self, mammogram):
-        location = (
-            mammogram.provider.name
-            if mammogram.provider
-            else mammogram.location_details
-        )
-        if mammogram.provider:
-            location = mammogram.provider.name
-        elif (
-            mammogram.location_details
-            and mammogram.location_type == mammogram.LocationType.ELSEWHERE_UK
-        ):
-            location = f"In the UK: {mammogram.location_details}"
-        elif (
-            mammogram.location_details
-            and mammogram.location_type == mammogram.LocationType.OUTSIDE_UK
-        ):
-            location = f"Outside the UK: {mammogram.location_details}"
-        elif mammogram.location_type == mammogram.LocationType.PREFER_NOT_TO_SAY:
-            location = "Location: prefer not to say"
-        else:
-            location = "Location unknown"
-
-        if mammogram.exact_date:
-            absolute = format_date(mammogram.exact_date)
-            relative = format_relative_date(mammogram.exact_date)
-            date = {"absolute": absolute, "relative": relative, "is_exact": True}
-        elif mammogram.approx_date:
-            date = {"value": f"Approximate date: {mammogram.approx_date}"}
-        else:
-            date = {"value": "Date unknown"}
-
-        return {
-            "date_added": format_relative_date(mammogram.created_at),
-            "location": location,
-            "date": date,
-            "different_name": mammogram.different_name,
-            "additional_information": mammogram.additional_information,
-        }
-
-    @cached_property
-    def add_link(self):
-        href = (
-            reverse(
-                "participants:add_previous_mammogram",
-                kwargs={"pk": self.participant_pk},
-            )
-            + f"?return_url={self.current_url}"
-        )
-        return {
-            "href": href,
-            "text": "Add another" if self.last_known_mammograms else "Add",
-            "visually_hidden_text": "mammogram",
         }
 
 

--- a/manage_breast_screening/mammograms/presenters/last_known_mammogram_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/last_known_mammogram_presenter.py
@@ -1,0 +1,78 @@
+from functools import cached_property
+
+from django.urls import reverse
+
+from manage_breast_screening.core.utils.date_formatting import (
+    format_date,
+    format_relative_date,
+)
+
+
+class LastKnownMammogramPresenter:
+    def __init__(self, last_known_mammograms, participant_pk, current_url):
+        self._last_known_mammograms = last_known_mammograms
+        self.participant_pk = participant_pk
+        self.current_url = current_url
+
+    @cached_property
+    def last_known_mammograms(self):
+        result = []
+        for mammogram in self._last_known_mammograms:
+            result.append(self._present_mammogram(mammogram))
+
+        return result
+
+    def _present_mammogram(self, mammogram):
+        location = (
+            mammogram.provider.name
+            if mammogram.provider
+            else mammogram.location_details
+        )
+        if mammogram.provider:
+            location = mammogram.provider.name
+        elif (
+            mammogram.location_details
+            and mammogram.location_type == mammogram.LocationType.ELSEWHERE_UK
+        ):
+            location = f"In the UK: {mammogram.location_details}"
+        elif (
+            mammogram.location_details
+            and mammogram.location_type == mammogram.LocationType.OUTSIDE_UK
+        ):
+            location = f"Outside the UK: {mammogram.location_details}"
+        elif mammogram.location_type == mammogram.LocationType.PREFER_NOT_TO_SAY:
+            location = "Location: prefer not to say"
+        else:
+            location = "Location unknown"
+
+        if mammogram.exact_date:
+            absolute = format_date(mammogram.exact_date)
+            relative = format_relative_date(mammogram.exact_date)
+            date = {"absolute": absolute, "relative": relative, "is_exact": True}
+        elif mammogram.approx_date:
+            date = {"value": f"Approximate date: {mammogram.approx_date}"}
+        else:
+            date = {"value": "Date unknown"}
+
+        return {
+            "date_added": format_relative_date(mammogram.created_at),
+            "location": location,
+            "date": date,
+            "different_name": mammogram.different_name,
+            "additional_information": mammogram.additional_information,
+        }
+
+    @cached_property
+    def add_link(self):
+        href = (
+            reverse(
+                "participants:add_previous_mammogram",
+                kwargs={"pk": self.participant_pk},
+            )
+            + f"?return_url={self.current_url}"
+        )
+        return {
+            "href": href,
+            "text": "Add another" if self.last_known_mammograms else "Add",
+            "visually_hidden_text": "mammogram",
+        }

--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+
+from manage_breast_screening.core.template_helpers import multiline_content
+from manage_breast_screening.core.utils.date_formatting import format_approximate_date
+from manage_breast_screening.participants.models.symptom import SymptomAreas
+
+from .appointment_presenters import AppointmentPresenter
+
+
+class MedicalInformationPresenter:
+    @dataclass
+    class PresentedSymptom:
+        symptom_type: str
+        location_line: str
+        started_line: str
+        investigated_line: str = ""
+        intermittent_line: str = ""
+        stopped_line: str = ""
+        additional_information_line: str = ""
+
+    def __init__(self, appointment):
+        self.appointment = AppointmentPresenter(appointment)
+
+        symptoms = appointment.symptom_set.select_related("symptom_type").order_by(
+            "symptom_type__name", "reported_at"
+        )
+        self.symptoms = [self._map_symptom(symptom) for symptom in symptoms]
+
+    def _map_symptom_area(self, symptom):
+        match symptom.area:
+            case SymptomAreas.RIGHT_BREAST:
+                return "Right breast"
+            case SymptomAreas.LEFT_BREAST:
+                return "Left breast"
+            case SymptomAreas.BOTH_BREASTS:
+                return "Both breasts"
+            case _:
+                return symptom.get_area_display()
+
+    def _map_symptom(self, symptom):
+        location = self._map_symptom_area(symptom)
+        started = symptom.get_when_started_display()
+        if symptom.year_started is not None and symptom.month_started is not None:
+            started = format_approximate_date(
+                symptom.year_started, symptom.month_started
+            )
+
+        investigated = (
+            f"Previously investigated: {symptom.investigation_details}"
+            if symptom.investigated
+            else "Not investigated"
+        )
+
+        intermittent = "Symptom is intermittent" if symptom.intermittent else ""
+        stopped = f"Stopped: {symptom.when_resolved}" if symptom.when_resolved else ""
+
+        additional_information = (
+            f"Additional information: {symptom.additional_information}"
+            if symptom.additional_information
+            else ""
+        )
+
+        return self.PresentedSymptom(
+            symptom_type=symptom.symptom_type.name,
+            location_line=location,
+            started_line=started,
+            investigated_line=investigated,
+            intermittent_line=intermittent,
+            stopped_line=stopped,
+            additional_information_line=additional_information,
+        )
+
+    @property
+    def symptom_rows(self):
+        result = []
+        for symptom in self.symptoms:
+            html = multiline_content(
+                [
+                    line
+                    for line in [
+                        symptom.location_line,
+                        symptom.started_line,
+                        symptom.investigated_line,
+                        symptom.intermittent_line,
+                        symptom.stopped_line,
+                        symptom.additional_information_line,
+                    ]
+                    if line
+                ]
+            )
+
+            result.append(
+                {
+                    "key": {"text": symptom.symptom_type},
+                    "value": {"html": html},
+                    "actions": {
+                        "items": [
+                            {
+                                "text": "Change",
+                                "visuallyHiddenText": symptom.symptom_type.lower(),
+                                "href": "#",
+                            }
+                        ]
+                    },
+                }
+            )
+        return result

--- a/manage_breast_screening/mammograms/tests/presenters/test_appointment_presenters.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_appointment_presenters.py
@@ -6,19 +6,13 @@ from uuid import UUID, uuid4
 import pytest
 import time_machine
 
-from manage_breast_screening.clinics.models import ClinicSlot, Provider
-from manage_breast_screening.participants.models import (
-    Appointment,
-    AppointmentStatus,
-    ParticipantReportedMammogram,
-)
-
-from ..presenters import (
+from manage_breast_screening.clinics.models import ClinicSlot
+from manage_breast_screening.mammograms.presenters import (
     AppointmentPresenter,
     ClinicSlotPresenter,
-    LastKnownMammogramPresenter,
     SpecialAppointmentPresenter,
 )
+from manage_breast_screening.participants.models import Appointment, AppointmentStatus
 
 
 class TestAppointmentPresenter:
@@ -155,107 +149,6 @@ class TestAppointmentPresenter:
         mock_appointment.screening_episode.participant.extra_needs = extra_needs
         presenter = AppointmentPresenter(mock_appointment)
         assert presenter.is_special_appointment == expected_result
-
-
-class TestLastKnownMammogramPresenter:
-    @pytest.fixture
-    def reported_today(self):
-        return ParticipantReportedMammogram(
-            created_at=datetime(2025, 1, 1),
-            location_type=ParticipantReportedMammogram.LocationType.ELSEWHERE_UK,
-            location_details="Somewhere",
-            exact_date=date(2022, 1, 1),
-        )
-
-    @pytest.fixture
-    def reported_earlier(self):
-        return ParticipantReportedMammogram(
-            created_at=datetime(2022, 1, 1),
-            provider=Provider(name="West of London BSS"),
-            location_type=ParticipantReportedMammogram.LocationType.NHS_BREAST_SCREENING_UNIT,
-            approx_date="3 years ago",
-            additional_information="Abcd",
-            different_name="Janet Williams",
-        )
-
-    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
-    def test_no_last_known_mammograms(self, reported_today):
-        result = LastKnownMammogramPresenter(
-            [],
-            participant_pk=uuid4(),
-            current_url="/mammograms/abc",
-        )
-
-        assert result.last_known_mammograms == []
-
-    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
-    def test_last_known_mammograms_single(self, reported_today):
-        result = LastKnownMammogramPresenter(
-            [reported_today],
-            participant_pk=uuid4(),
-            current_url="/mammograms/abc",
-        )
-
-        assert result.last_known_mammograms == [
-            {
-                "date_added": "today",
-                "additional_information": "",
-                "date": {
-                    "absolute": "1 January 2022",
-                    "relative": "3 years ago",
-                    "is_exact": True,
-                },
-                "different_name": "",
-                "location": "In the UK: Somewhere",
-            },
-        ]
-
-    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
-    def test_last_known_mammograms_multiple(self, reported_today, reported_earlier):
-        result = LastKnownMammogramPresenter(
-            [reported_today, reported_earlier],
-            participant_pk=uuid4(),
-            current_url="/mammograms/abc",
-        )
-
-        assert result.last_known_mammograms == [
-            {
-                "date_added": "today",
-                "additional_information": "",
-                "date": {
-                    "absolute": "1 January 2022",
-                    "relative": "3 years ago",
-                    "is_exact": True,
-                },
-                "different_name": "",
-                "location": "In the UK: Somewhere",
-            },
-            {
-                "date_added": "3 years ago",
-                "additional_information": "Abcd",
-                "date": {
-                    "value": "Approximate date: 3 years ago",
-                },
-                "different_name": "Janet Williams",
-                "location": "West of London BSS",
-            },
-        ]
-
-    def test_add_link(self, reported_today):
-        participant_id = uuid4()
-        current_url = "/mammograms/abc"
-
-        result = LastKnownMammogramPresenter(
-            [reported_today],
-            participant_pk=participant_id,
-            current_url=current_url,
-        )
-
-        assert result.add_link == {
-            "href": f"/participants/{participant_id}/previous-mammograms/add?return_url={current_url}",
-            "text": "Add another",
-            "visually_hidden_text": "mammogram",
-        }
 
 
 class TestClinicSlotPresenter:

--- a/manage_breast_screening/mammograms/tests/presenters/test_last_known_mammogram_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_last_known_mammogram_presenter.py
@@ -1,0 +1,111 @@
+from datetime import date, datetime
+from datetime import timezone as tz
+from uuid import uuid4
+
+import pytest
+import time_machine
+
+from manage_breast_screening.clinics.models import Provider
+from manage_breast_screening.mammograms.presenters import LastKnownMammogramPresenter
+from manage_breast_screening.participants.models import ParticipantReportedMammogram
+
+
+class TestLastKnownMammogramPresenter:
+    @pytest.fixture
+    def reported_today(self):
+        return ParticipantReportedMammogram(
+            created_at=datetime(2025, 1, 1),
+            location_type=ParticipantReportedMammogram.LocationType.ELSEWHERE_UK,
+            location_details="Somewhere",
+            exact_date=date(2022, 1, 1),
+        )
+
+    @pytest.fixture
+    def reported_earlier(self):
+        return ParticipantReportedMammogram(
+            created_at=datetime(2022, 1, 1),
+            provider=Provider(name="West of London BSS"),
+            location_type=ParticipantReportedMammogram.LocationType.NHS_BREAST_SCREENING_UNIT,
+            approx_date="3 years ago",
+            additional_information="Abcd",
+            different_name="Janet Williams",
+        )
+
+    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
+    def test_no_last_known_mammograms(self, reported_today):
+        result = LastKnownMammogramPresenter(
+            [],
+            participant_pk=uuid4(),
+            current_url="/mammograms/abc",
+        )
+
+        assert result.last_known_mammograms == []
+
+    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
+    def test_last_known_mammograms_single(self, reported_today):
+        result = LastKnownMammogramPresenter(
+            [reported_today],
+            participant_pk=uuid4(),
+            current_url="/mammograms/abc",
+        )
+
+        assert result.last_known_mammograms == [
+            {
+                "date_added": "today",
+                "additional_information": "",
+                "date": {
+                    "absolute": "1 January 2022",
+                    "relative": "3 years ago",
+                    "is_exact": True,
+                },
+                "different_name": "",
+                "location": "In the UK: Somewhere",
+            },
+        ]
+
+    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
+    def test_last_known_mammograms_multiple(self, reported_today, reported_earlier):
+        result = LastKnownMammogramPresenter(
+            [reported_today, reported_earlier],
+            participant_pk=uuid4(),
+            current_url="/mammograms/abc",
+        )
+
+        assert result.last_known_mammograms == [
+            {
+                "date_added": "today",
+                "additional_information": "",
+                "date": {
+                    "absolute": "1 January 2022",
+                    "relative": "3 years ago",
+                    "is_exact": True,
+                },
+                "different_name": "",
+                "location": "In the UK: Somewhere",
+            },
+            {
+                "date_added": "3 years ago",
+                "additional_information": "Abcd",
+                "date": {
+                    "value": "Approximate date: 3 years ago",
+                },
+                "different_name": "Janet Williams",
+                "location": "West of London BSS",
+            },
+        ]
+
+    def test_add_link(self, reported_today):
+        participant_id = uuid4()
+        current_url = "/mammograms/abc"
+
+        result = LastKnownMammogramPresenter(
+            [reported_today],
+            participant_pk=participant_id,
+            current_url=current_url,
+        )
+
+        assert result.add_link == {
+            "href": f"/participants/{participant_id}/previous-mammograms/add?return_url={current_url}",
+            "text": "Add another",
+            "visually_hidden_text": "mammogram",
+        }

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -1,0 +1,148 @@
+import pytest
+
+from manage_breast_screening.mammograms.presenters.medical_information_presenter import (
+    MedicalInformationPresenter,
+)
+from manage_breast_screening.participants.models.symptom import (
+    RelativeDateChoices,
+    SymptomAreas,
+)
+from manage_breast_screening.participants.tests.factories import (
+    AppointmentFactory,
+    SymptomFactory,
+)
+
+
+@pytest.mark.django_db
+class TestRecordMedicalInformationPresenter:
+    @pytest.mark.parametrize(
+        "area, expected_location",
+        [
+            (SymptomAreas.RIGHT_BREAST, "Right breast"),
+            (SymptomAreas.LEFT_BREAST, "Left breast"),
+            (SymptomAreas.OTHER, "Other"),
+        ],
+    )
+    def test_returns_symptoms(self, area, expected_location):
+        symptom = SymptomFactory.create(
+            lump=True,
+            when_started=RelativeDateChoices.LESS_THAN_THREE_MONTHS,
+            area=area,
+            investigated=False,
+        )
+
+        presenter = MedicalInformationPresenter(symptom.appointment)
+
+        assert presenter.symptoms == [
+            MedicalInformationPresenter.PresentedSymptom(
+                symptom_type="Lump",
+                location_line=expected_location,
+                started_line="Less than 3 months",
+                investigated_line="Not investigated",
+            ),
+        ]
+
+    def test_formats_investigation_and_specific_date(self):
+        symptom = SymptomFactory.create(
+            lump=True,
+            when_started=RelativeDateChoices.SINCE_A_SPECIFIC_DATE,
+            year_started=2025,
+            month_started=1,
+            area=SymptomAreas.RIGHT_BREAST,
+            investigated=True,
+            investigation_details="abc",
+        )
+
+        presenter = MedicalInformationPresenter(symptom.appointment)
+
+        assert presenter.symptoms == [
+            MedicalInformationPresenter.PresentedSymptom(
+                symptom_type="Lump",
+                location_line="Right breast",
+                started_line="January 2025 (8 months ago)",
+                investigated_line="Previously investigated: abc",
+            ),
+        ]
+
+    def test_formats_intermittent_stopped_and_additional_information(self):
+        symptom = SymptomFactory.create(
+            lump=True,
+            when_started=RelativeDateChoices.NOT_SURE,
+            area=SymptomAreas.LEFT_BREAST,
+            intermittent=True,
+            when_resolved="resolved date",
+            additional_information="abc",
+        )
+
+        presenter = MedicalInformationPresenter(symptom.appointment)
+
+        assert presenter.symptoms == [
+            MedicalInformationPresenter.PresentedSymptom(
+                symptom_type="Lump",
+                location_line="Left breast",
+                started_line="Not sure",
+                stopped_line="Stopped: resolved date",
+                investigated_line="Not investigated",
+                intermittent_line="Symptom is intermittent",
+                additional_information_line="Additional information: abc",
+            ),
+        ]
+
+    def test_formats_for_summary_list(self):
+        appointment = AppointmentFactory.create()
+
+        SymptomFactory.create(
+            lump=True,
+            appointment=appointment,
+            when_started=RelativeDateChoices.NOT_SURE,
+            area=SymptomAreas.LEFT_BREAST,
+            intermittent=True,
+            when_resolved="resolved date",
+            additional_information="abc",
+        )
+
+        SymptomFactory.create(
+            skin_change=True,
+            appointment=appointment,
+            when_started=RelativeDateChoices.LESS_THAN_THREE_MONTHS,
+            area=SymptomAreas.BOTH_BREASTS,
+        )
+
+        presenter = MedicalInformationPresenter(appointment)
+
+        assert presenter.symptom_rows == [
+            {
+                "actions": {
+                    "items": [
+                        {
+                            "href": "#",
+                            "text": "Change",
+                            "visuallyHiddenText": "lump",
+                        },
+                    ],
+                },
+                "key": {
+                    "text": "Lump",
+                },
+                "value": {
+                    "html": "Left breast<br>Not sure<br>Not investigated<br>Symptom is intermittent<br>Stopped: resolved date<br>Additional information: abc",
+                },
+            },
+            {
+                "actions": {
+                    "items": [
+                        {
+                            "href": "#",
+                            "text": "Change",
+                            "visuallyHiddenText": "skin change",
+                        },
+                    ],
+                },
+                "key": {
+                    "text": "Skin change",
+                },
+                "value": {
+                    "html": "Both breasts<br>Less than 3 months<br>Not investigated",
+                },
+            },
+        ]

--- a/manage_breast_screening/mammograms/tests/views/test_appointment_flow.py
+++ b/manage_breast_screening/mammograms/tests/views/test_appointment_flow.py
@@ -138,6 +138,18 @@ class TestAskForMedicalInformation:
 
 
 @pytest.mark.django_db
+class TestRecordMedicalInformation:
+    def test_renders_response(self, clinical_user_client, appointment):
+        response = clinical_user_client.get(
+            reverse(
+                "mammograms:record_medical_information",
+                kwargs={"pk": appointment.pk},
+            )
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
 class TestCheckIn:
     def test_known_redirect(self, clinical_user_client, appointment):
         response = clinical_user_client.post(

--- a/manage_breast_screening/mammograms/views/appointment_flow.py
+++ b/manage_breast_screening/mammograms/views/appointment_flow.py
@@ -10,6 +10,9 @@ from django.views.generic import FormView, TemplateView
 
 from manage_breast_screening.auth.models import Permission
 from manage_breast_screening.core.services.auditor import Auditor
+from manage_breast_screening.mammograms.presenters.medical_information_presenter import (
+    MedicalInformationPresenter,
+)
 from manage_breast_screening.participants.models import (
     Appointment,
     AppointmentStatus,
@@ -218,6 +221,7 @@ class RecordMedicalInformation(InProgressAppointmentMixin, FormView):
                 "page_title": "Record medical information",
                 "participant": participant,
                 "caption": participant.full_name,
+                "presenter": MedicalInformationPresenter(self.appointment),
             }
         )
         return context

--- a/manage_breast_screening/nonprod/management/commands/seed_demo_data.py
+++ b/manage_breast_screening/nonprod/management/commands/seed_demo_data.py
@@ -27,6 +27,7 @@ from manage_breast_screening.participants.models import (
     ParticipantReportedMammogram,
     ScreeningEpisode,
 )
+from manage_breast_screening.participants.models.symptom import Symptom
 from manage_breast_screening.participants.tests.factories import (
     AppointmentFactory,
     AppointmentStatusFactory,
@@ -34,6 +35,7 @@ from manage_breast_screening.participants.tests.factories import (
     ParticipantFactory,
     ParticipantReportedMammogramFactory,
     ScreeningEpisodeFactory,
+    SymptomFactory,
 )
 
 logger = logging.getLogger(__name__)
@@ -151,6 +153,9 @@ class Command(BaseCommand):
                 state=status_key,
             )
 
+        for symptom in appointment_key.get("symptoms", []):
+            self.create_symptom(appointment, symptom)
+
         return appointment
 
     def create_screening_episode(self, screening_episode_key):
@@ -175,6 +180,9 @@ class Command(BaseCommand):
         self.create_reported_mammograms(participant, previous_mammograms_key)
         return participant
 
+    def create_symptom(self, appointment, symptom):
+        SymptomFactory(appointment=appointment, **symptom)
+
     def create_reported_mammograms(self, participant, mammograms):
         for mammogram in mammograms:
             created_at_date = mammogram.pop("created_at", None)
@@ -194,6 +202,7 @@ class Command(BaseCommand):
             return participant_mammogram
 
     def reset_db(self):
+        Symptom.objects.all().delete()
         AppointmentStatus.objects.all().delete()
         Appointment.objects.all().delete()
         ParticipantReportedMammogram.objects.all().delete()

--- a/manage_breast_screening/participants/tests/factories.py
+++ b/manage_breast_screening/participants/tests/factories.py
@@ -1,7 +1,14 @@
 from datetime import date
 
-from factory import Sequence, Trait, post_generation
-from factory.declarations import RelatedFactory, SubFactory
+from factory import post_generation
+from factory.declarations import (
+    Iterator,
+    LazyFunction,
+    RelatedFactory,
+    Sequence,
+    SubFactory,
+    Trait,
+)
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
@@ -110,4 +117,38 @@ class AppointmentFactory(DjangoModelFactory):
 
         obj.statuses.add(
             AppointmentStatusFactory.create(state=extracted, appointment=obj)
+        )
+
+
+class SymptomFactory(DjangoModelFactory):
+    class Meta:
+        model = models.Symptom
+        skip_postgeneration_save = True
+
+    reported_at = LazyFunction(date.today)
+    area = Iterator(models.SymptomAreas)
+    intermittent = False
+    investigated = False
+    recently_resolved = False
+    appointment = SubFactory(AppointmentFactory)
+
+    class Params:
+        lump = Trait(
+            symptom_type_id=models.SymptomType.LUMP,
+        )
+
+        nipple_change = Trait(
+            symptom_type_id=models.SymptomType.NIPPLE_CHANGE,
+        )
+
+        skin_change = Trait(
+            symptom_type_id=models.SymptomType.SKIN_CHANGE,
+        )
+
+        swelling_or_shape_change = Trait(
+            symptom_type_id=models.SymptomType.SWELLING_OR_SHAPE_CHANGE,
+        )
+
+        other = Trait(
+            symptom_type_id=models.SymptomType.OTHER,
         )


### PR DESCRIPTION
## Description

In order to implement the forms for recording symptoms, we need to make sure they are shown to users on the record medical information page.

The seed command for non prod environments also needs updating to handle symptom data.

This PR implements the symptoms card to match the prototype. A couple of things are left out, e.g. I didn't add subtype yet as it's not needed for the symptom types I'm implementing at the moment. The links will be added in the PR that adds the forms, and we will have one add link for each symptom type.

<img width="985" height="418" alt="Symptoms card with a symptom" src="https://github.com/user-attachments/assets/34223dc3-f2ba-473d-8ea0-836bc6187156" />

<img width="983" height="306" alt="Symptoms card with no symptoms" src="https://github.com/user-attachments/assets/0ddbbe3a-4835-41d0-89fe-a3649641aec0" />


## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10971

## Review notes
- I've had to implement new helpers for formatting dates without a day component. I noticed there was an edge case not handled correctly by the prototype where the user enters the current month. I've made it display "this month" in this case, rather than "1 month". Let me know if there are additional edge cases to consider here, or the copy needs changing.  
- I refactored the mammograms app's presenters into a package with multiple modules, having already split up the models, forms, and views previously. To make jumping around the codebase easier, I wanted to avoid having so many modules with the same name (e.g. presenters.py or symptoms.py).
- I've pushed the logic for building the summary list params into the presenter. I'm not sure we can do this for every use of the summary list, but in this case, where `value.html` is just text it seems cleaner to do it this way.