### PR TITLE
[Bug] Remove extra json serialisation

### DIFF
--- a/manage_breast_screening/notifications/services/queue.py
+++ b/manage_breast_screening/notifications/services/queue.py
@@ -21,7 +21,7 @@ class Queue:
         elif connection_string:
             try:
                 self.client = QueueClient.from_connection_string(
-                    os.getenv("QUEUE_STORAGE_CONNECTION_STRING"), queue_name
+                    connection_string, queue_name
                 )
                 self.client.create_queue()
             except ResourceExistsError:

--- a/manage_breast_screening/notifications/tests/integration/test_retry_message_batches_from_queue.py
+++ b/manage_breast_screening/notifications/tests/integration/test_retry_message_batches_from_queue.py
@@ -83,9 +83,7 @@ class TestRetryMessageBatchesFromQueue:
         }
 
         mock_send_message_batch.return_value.status_code = 400
-        mock_send_message_batch.return_value.json.return_value = json.dumps(
-            notify_errors
-        )
+        mock_send_message_batch.return_value.json.return_value = notify_errors
 
         invalid_message = MessageFactory(status="failed")
         ok_message_1 = MessageFactory(status="failed")
@@ -106,4 +104,4 @@ class TestRetryMessageBatchesFromQueue:
         invalid_message.refresh_from_db()
         assert invalid_message.status == "failed"
         assert invalid_message.batch is None
-        assert invalid_message.nhs_notify_errors == json.dumps(notify_errors["errors"])
+        assert invalid_message.nhs_notify_errors == notify_errors["errors"]


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Removes unnecessary JSON serialisation when persisting error messages.
A couple of small refactors.
Discovered when testing against integration NHS Notify API. Prevents message batches which fail validation from being retried.

#### Before (dev db, test data)
<img width="433" height="168" alt="image" src="https://github.com/user-attachments/assets/861db841-8505-4b7e-8154-212cf2d0606f" />

#### After
<img width="448" height="194" alt="image" src="https://github.com/user-attachments/assets/a3ebfe3e-5a7c-4ecc-8d1e-9e6ad4be2ee9" />



<!-- Add screenshots if there are any UI updates. -->

## Jira link

## Review notes

<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
