### PR TITLE
[DTOS-10724] extend add lump form to handle changes

### DIFF
--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 
 from manage_breast_screening.core.template_helpers import multiline_content
 from manage_breast_screening.core.utils.date_formatting import format_approximate_date
-from manage_breast_screening.participants.models.symptom import SymptomAreas
 
 from .appointment_presenters import AppointmentPresenter
 
@@ -59,21 +58,13 @@ class MedicalInformationPresenter:
         symptoms = appointment.symptom_set.select_related("symptom_type").order_by(
             "symptom_type__name", "reported_at"
         )
-        self.symptoms = [self._map_symptom(symptom) for symptom in symptoms]
+        self.symptoms = [self._present_symptom(symptom) for symptom in symptoms]
 
-    def _map_symptom_area(self, symptom):
-        match symptom.area:
-            case SymptomAreas.RIGHT_BREAST:
-                return "Right breast"
-            case SymptomAreas.LEFT_BREAST:
-                return "Left breast"
-            case SymptomAreas.BOTH_BREASTS:
-                return "Both breasts"
-            case _:
-                return symptom.get_area_display()
+    def _present_symptom_area(self, symptom):
+        return symptom.get_area_display()
 
-    def _map_symptom(self, symptom):
-        location = self._map_symptom_area(symptom)
+    def _present_symptom(self, symptom):
+        location = self._present_symptom_area(symptom)
         started = symptom.get_when_started_display()
         if symptom.year_started is not None and symptom.month_started is not None:
             started = format_approximate_date(

--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -46,7 +46,13 @@ class MedicalInformationPresenter:
                         {
                             "text": "Change",
                             "visuallyHiddenText": self.symptom_type.lower(),
-                            "href": "#",
+                            "href": reverse(
+                                "mammograms:change_symptom_lump",
+                                kwargs={
+                                    "pk": self.appointment_id,
+                                    "lump_pk": self.id,
+                                },
+                            ),
                         }
                     ]
                 },

--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -12,6 +12,8 @@ from .appointment_presenters import AppointmentPresenter
 class MedicalInformationPresenter:
     @dataclass
     class PresentedSymptom:
+        id: str
+        appointment_id: str
         symptom_type: str
         location_line: str
         started_line: str
@@ -19,6 +21,37 @@ class MedicalInformationPresenter:
         intermittent_line: str = ""
         stopped_line: str = ""
         additional_information_line: str = ""
+
+        @property
+        def summary_list_row(self):
+            html = multiline_content(
+                [
+                    line
+                    for line in [
+                        self.location_line,
+                        self.started_line,
+                        self.investigated_line,
+                        self.intermittent_line,
+                        self.stopped_line,
+                        self.additional_information_line,
+                    ]
+                    if line
+                ]
+            )
+
+            return {
+                "key": {"text": self.symptom_type},
+                "value": {"html": html},
+                "actions": {
+                    "items": [
+                        {
+                            "text": "Change",
+                            "visuallyHiddenText": self.symptom_type.lower(),
+                            "href": "#",
+                        }
+                    ]
+                },
+            }
 
     def __init__(self, appointment):
         self.appointment = AppointmentPresenter(appointment)
@@ -63,6 +96,8 @@ class MedicalInformationPresenter:
         )
 
         return self.PresentedSymptom(
+            id=symptom.id,
+            appointment_id=symptom.appointment_id,
             symptom_type=symptom.symptom_type.name,
             location_line=location,
             started_line=started,
@@ -74,39 +109,7 @@ class MedicalInformationPresenter:
 
     @property
     def symptom_rows(self):
-        result = []
-        for symptom in self.symptoms:
-            html = multiline_content(
-                [
-                    line
-                    for line in [
-                        symptom.location_line,
-                        symptom.started_line,
-                        symptom.investigated_line,
-                        symptom.intermittent_line,
-                        symptom.stopped_line,
-                        symptom.additional_information_line,
-                    ]
-                    if line
-                ]
-            )
-
-            result.append(
-                {
-                    "key": {"text": symptom.symptom_type},
-                    "value": {"html": html},
-                    "actions": {
-                        "items": [
-                            {
-                                "text": "Change",
-                                "visuallyHiddenText": symptom.symptom_type.lower(),
-                                "href": "#",
-                            }
-                        ]
-                    },
-                }
-            )
-        return result
+        return [symptom.summary_list_row for symptom in self.symptoms]
 
     @property
     def add_lump_link(self):

--- a/manage_breast_screening/mammograms/tests/forms/test_symptom_forms.py
+++ b/manage_breast_screening/mammograms/tests/forms/test_symptom_forms.py
@@ -11,7 +11,10 @@ from manage_breast_screening.participants.models.symptom import (
     SymptomAreas,
     SymptomType,
 )
-from manage_breast_screening.participants.tests.factories import AppointmentFactory
+from manage_breast_screening.participants.tests.factories import (
+    AppointmentFactory,
+    SymptomFactory,
+)
 
 
 class TestLumpForm:
@@ -68,7 +71,7 @@ class TestLumpForm:
         assert form.is_valid()
 
     @pytest.mark.django_db
-    def test_save(self, clinical_user):
+    def test_create(self, clinical_user):
         appointment = AppointmentFactory.create()
         request = RequestFactory().get("/test-form")
         request.user = clinical_user
@@ -87,7 +90,7 @@ class TestLumpForm:
 
         assert form.is_valid()
 
-        obj = form.save(appointment=appointment, request=request)
+        obj = form.create(appointment=appointment, request=request)
 
         assert obj.appointment == appointment
         assert obj.symptom_type_id == SymptomType.LUMP
@@ -119,9 +122,43 @@ class TestLumpForm:
 
         assert form.is_valid()
 
-        obj = form.save(appointment=appointment, request=request)
+        obj = form.create(appointment=appointment, request=request)
 
         assert not obj.area_description
         assert not obj.investigation_details
         assert not obj.year_started
         assert not obj.month_started
+
+    @pytest.mark.django_db
+    def test_update(self, clinical_user):
+        appointment = AppointmentFactory.create()
+        symptom = SymptomFactory.create(
+            lump=True,
+            area=RightLeftOtherChoices.LEFT_BREAST,
+            when_started=RelativeDateChoices.ONE_TO_THREE_YEARS,
+            investigated=False,
+            appointment=appointment,
+        )
+        request = RequestFactory().get("/test-form")
+        request.user = clinical_user
+
+        form = LumpForm(
+            data={
+                "area": RightLeftOtherChoices.LEFT_BREAST,
+                "when_started": RelativeDateChoices.ONE_TO_THREE_YEARS,
+                "investigated": YesNo.YES,
+                "investigation_details": "abc",
+            },
+            instance=symptom,
+        )
+
+        assert form.is_valid()
+
+        obj = form.update(request=request)
+
+        assert obj.appointment == appointment
+        assert obj.symptom_type_id == SymptomType.LUMP
+        assert obj.area == SymptomAreas.LEFT_BREAST
+        assert obj.investigated
+        assert obj.investigation_details == "abc"
+        assert obj.when_started == RelativeDateChoices.ONE_TO_THREE_YEARS

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -35,6 +35,8 @@ class TestRecordMedicalInformationPresenter:
 
         assert presenter.symptoms == [
             MedicalInformationPresenter.PresentedSymptom(
+                id=symptom.id,
+                appointment_id=symptom.appointment_id,
                 symptom_type="Lump",
                 location_line=expected_location,
                 started_line="Less than 3 months",
@@ -57,6 +59,8 @@ class TestRecordMedicalInformationPresenter:
 
         assert presenter.symptoms == [
             MedicalInformationPresenter.PresentedSymptom(
+                id=symptom.id,
+                appointment_id=symptom.appointment_id,
                 symptom_type="Lump",
                 location_line="Right breast",
                 started_line="January 2025 (8 months ago)",
@@ -78,6 +82,8 @@ class TestRecordMedicalInformationPresenter:
 
         assert presenter.symptoms == [
             MedicalInformationPresenter.PresentedSymptom(
+                id=symptom.id,
+                appointment_id=symptom.appointment_id,
                 symptom_type="Lump",
                 location_line="Left breast",
                 started_line="Not sure",

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -97,7 +97,7 @@ class TestRecordMedicalInformationPresenter:
     def test_formats_for_summary_list(self):
         appointment = AppointmentFactory.create()
 
-        SymptomFactory.create(
+        symptom1 = SymptomFactory.create(
             lump=True,
             appointment=appointment,
             when_started=RelativeDateChoices.NOT_SURE,
@@ -107,7 +107,7 @@ class TestRecordMedicalInformationPresenter:
             additional_information="abc",
         )
 
-        SymptomFactory.create(
+        symptom2 = SymptomFactory.create(
             skin_change=True,
             appointment=appointment,
             when_started=RelativeDateChoices.LESS_THAN_THREE_MONTHS,
@@ -121,7 +121,7 @@ class TestRecordMedicalInformationPresenter:
                 "actions": {
                     "items": [
                         {
-                            "href": "#",
+                            "href": f"/mammograms/{appointment.id}/record-medical-information/lump/{symptom1.id}/",
                             "text": "Change",
                             "visuallyHiddenText": "lump",
                         },
@@ -138,7 +138,7 @@ class TestRecordMedicalInformationPresenter:
                 "actions": {
                     "items": [
                         {
-                            "href": "#",
+                            "href": f"/mammograms/{appointment.id}/record-medical-information/lump/{symptom2.id}/",
                             "text": "Change",
                             "visuallyHiddenText": "skin change",
                         },

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -52,7 +52,12 @@ urlpatterns = [
     ),
     path(
         "<uuid:pk>/record-medical-information/lump/",
-        symptom_views.AddLump.as_view(),
+        symptom_views.AddOrChangeLump.as_view(),
         name="add_symptom_lump",
+    ),
+    path(
+        "<uuid:pk>/record-medical-information/lump/<uuid:lump_pk>/",
+        symptom_views.AddOrChangeLump.as_view(),
+        name="change_symptom_lump",
     ),
 ]

--- a/manage_breast_screening/nhsuk_forms/utils.py
+++ b/manage_breast_screening/nhsuk_forms/utils.py
@@ -4,3 +4,10 @@ from .fields.choice_fields import ChoiceField
 
 def yes_no_field(**kwargs) -> ChoiceField:
     return ChoiceField(choices=YesNo, **kwargs)
+
+
+def yes_no(bool):
+    if bool:
+        return YesNo.YES
+    else:
+        return YesNo.NO

--- a/manage_breast_screening/tests/system/clinical/test_recording_symptoms.py
+++ b/manage_breast_screening/tests/system/clinical/test_recording_symptoms.py
@@ -2,11 +2,15 @@ import pytest
 from django.urls import reverse
 from playwright.sync_api import expect
 
-from manage_breast_screening.participants.models.symptom import SymptomType
+from manage_breast_screening.participants.models.symptom import (
+    RelativeDateChoices,
+    SymptomType,
+)
 from manage_breast_screening.participants.tests.factories import (
     AppointmentFactory,
     ParticipantFactory,
     ScreeningEpisodeFactory,
+    SymptomFactory,
 )
 
 from ..system_test_setup import SystemTestCase
@@ -34,11 +38,35 @@ class TestRecordingSymptoms(SystemTestCase):
         self.then_i_am_back_on_the_medical_information_page()
         self.and_the_lump_on_the_right_breast_is_listed()
 
+    def test_changing_a_symptom(self):
+        self.given_i_am_logged_in_as_a_clinical_user()
+        self.and_there_is_an_appointment_with_a_symptom_added_in_the_last_three_months()
+        self.and_i_am_on_the_record_medical_information_page()
+        self.when_i_click_on_change()
+        self.then_less_than_three_months_should_be_selected()
+
+        self.when_i_select_three_months_to_a_year()
+        self.and_i_click_save_symptom()
+
+        self.then_i_am_back_on_the_medical_information_page()
+        self.and_i_see_three_months_to_a_year()
+
     def and_there_is_an_appointment(self):
         self.participant = ParticipantFactory(first_name="Janet", last_name="Williams")
         self.screening_episode = ScreeningEpisodeFactory(participant=self.participant)
         self.appointment = AppointmentFactory(screening_episode=self.screening_episode)
         self.provider = self.appointment.provider
+
+    def and_there_is_an_appointment_with_a_symptom_added_in_the_last_three_months(self):
+        self.participant = ParticipantFactory(first_name="Janet", last_name="Williams")
+        self.screening_episode = ScreeningEpisodeFactory(participant=self.participant)
+        self.appointment = AppointmentFactory(screening_episode=self.screening_episode)
+        self.provider = self.appointment.provider
+        self.symptom = SymptomFactory(
+            appointment=self.appointment,
+            lump=True,
+            when_started=RelativeDateChoices.LESS_THAN_THREE_MONTHS,
+        )
 
     def and_i_am_on_the_record_medical_information_page(self):
         self.page.goto(
@@ -61,6 +89,9 @@ class TestRecordingSymptoms(SystemTestCase):
     def and_i_select_less_than_three_months(self):
         self.page.get_by_label("Less than 3 months").click()
 
+    def when_i_select_three_months_to_a_year(self):
+        self.page.get_by_label("3 months to a year").click()
+
     def and_i_select_no_the_symptom_has_not_been_investigated(self):
         legend = self.page.get_by_text("Has this been investigated?")
         fieldset = self.page.get_by_role("group").filter(has=legend)
@@ -78,3 +109,20 @@ class TestRecordingSymptoms(SystemTestCase):
         )
         row = self.page.locator(".nhsuk-summary-list__row").filter(has=key)
         expect(row).to_contain_text("Right breast")
+
+    def when_i_click_on_change(self):
+        key = self.page.locator(
+            ".nhsuk-summary-list__key", has=self.page.get_by_text("Lump", exact=True)
+        )
+        row = self.page.locator(".nhsuk-summary-list__row").filter(has=key)
+        row.get_by_text("Change").click()
+
+    def then_less_than_three_months_should_be_selected(self):
+        expect(self.page.get_by_label("Less than 3 months")).to_be_checked()
+
+    def and_i_see_three_months_to_a_year(self):
+        key = self.page.locator(
+            ".nhsuk-summary-list__key", has=self.page.get_by_text("Lump", exact=True)
+        )
+        row = self.page.locator(".nhsuk-summary-list__row").filter(has=key)
+        expect(row).to_contain_text("3 months to a year")


### PR DESCRIPTION
## Description

This extends the form for adding lumps to also function as an update form. All the existing validation is unchanged.

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10724

## Review notes

A few things I want to get a second opinion on here

1. I feel like I'm reinventing functionality of Django's [model form](https://docs.djangoproject.com/en/5.2/topics/forms/modelforms/) here. The reason we've not used model forms so far (I think both me and @malcolmbaig have both tried this with previous forms) is because our forms are more complicated than the basic use case; they have fields which are conditional on other fields, and sometimes there is not a clean mapping between form fields and model fields, e.g. in this one we have 'exact date' which is a multi field, but it corresponds to two integer fields on the model (and therefore the model form implementation winds up needing a lot of customisation). That said, can you think of a cleaner way to implement the basic CRUD operations than what I've done? I'm expecting to repeat the pattern for other symptom types and other medical information.
2. I think the `AddOrChangeLump` view could be split into 2 views, but they are mostly the same. WDYT?
3.  I think this is a bit light on unit tests atm, do you think it's worth parametrising the `test_update` with some different submissions?