### PR TITLE
[DTOS-10724] delete functionality for lumps

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -43,3 +43,8 @@ a[href="#"] {
   right: 0;
   text-align: right;
 }
+
+.app-link--error,
+.app-link--warning {
+  color: $nhsuk-error-colour;
+}

--- a/manage_breast_screening/core/jinja2/layout-confirmation.jinja
+++ b/manage_breast_screening/core/jinja2/layout-confirmation.jinja
@@ -1,0 +1,39 @@
+{% extends "layout-app.jinja" %}
+{% from 'nhsuk/components/button/macro.jinja' import button %}
+
+{% block header %}
+  {{ header({
+    "service": {
+      "name": "Manage breast screening"
+    },
+    "account": {
+      "items": header_account_items(request.user)
+    }
+  }) }}
+{% endblock %}
+
+{% block page_content %}
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <h1 class="nhsuk-heading-l">
+      {{ heading | default('Are you sure?') }}
+    </h1>
+
+    {% block details %}
+    {% endblock %}
+
+    <form method="post" action="{{ confirm_action.href | default(request.path) }}">
+      <div class="nhsuk-button-group">
+        {{ button({
+          "text": confirm_action.text,
+          "classes": confirm_action.classes | default("nhsuk-button--warning")
+        }) }}
+        {{ csrf_input }}
+
+        <a class="nhsuk-link--no-visited-state" href="{{ cancel_action.href }}">{{ cancel_action.text | default('Cancel') }}</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/confirm_delete_lump.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/confirm_delete_lump.jinja
@@ -1,0 +1,19 @@
+{% extends "layout-confirmation.jinja" %}
+{% from 'nhsuk/components/summary-list/macro.jinja' import summaryList %}
+{% from 'nhsuk/components/inset-text/macro.jinja' import insetText %}
+
+{% block details %}
+  {{ summaryList({
+    "rows": [summary_list_row],
+    "classes": "nhsuk-summary-list--no-border"
+  }) }}
+
+
+  {% set insetTextHtml %}
+    <p>This action is final and cannot be undone.</p>
+  {% endset %}
+
+  {{ insetText({
+    "html": insetTextHtml
+  }) }}
+{% endblock %}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
@@ -42,4 +42,12 @@
       "text": "Save symptom"
     }) }}
   </div>
+
+  {% if delete_link %}
+    <p class="nhsuk-u-margin-top-4">
+      <a href="{{ delete_link.href }}" class="{{ delete_link.class }}">
+        {{ delete_link.text }}
+      </a>
+    </p>
+  {% endif %}
 {% endblock %}

--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -70,6 +70,9 @@ class PresentedSymptom:
 
     @property
     def summary_list_row(self):
+        return self.build_summary_list_row()
+
+    def build_summary_list_row(self, include_actions=True):
         html = multiline_content(
             [
                 line
@@ -85,10 +88,13 @@ class PresentedSymptom:
             ]
         )
 
-        return {
+        result = {
             "key": {"text": self.symptom_type_name},
             "value": {"html": html},
-            "actions": {
+        }
+
+        if include_actions:
+            result["actions"] = {
                 "items": [
                     {
                         "text": "Change",
@@ -102,8 +108,9 @@ class PresentedSymptom:
                         ),
                     }
                 ]
-            },
-        }
+            }
+
+        return result
 
 
 class MedicalInformationPresenter:

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -2,6 +2,7 @@ import pytest
 
 from manage_breast_screening.mammograms.presenters.medical_information_presenter import (
     MedicalInformationPresenter,
+    PresentedSymptom,
 )
 from manage_breast_screening.participants.models.symptom import (
     RelativeDateChoices,
@@ -34,7 +35,7 @@ class TestRecordMedicalInformationPresenter:
         presenter = MedicalInformationPresenter(symptom.appointment)
 
         assert presenter.symptoms == [
-            MedicalInformationPresenter.PresentedSymptom(
+            PresentedSymptom(
                 id=symptom.id,
                 appointment_id=symptom.appointment_id,
                 symptom_type_id="lump",
@@ -59,7 +60,7 @@ class TestRecordMedicalInformationPresenter:
         presenter = MedicalInformationPresenter(symptom.appointment)
 
         assert presenter.symptoms == [
-            MedicalInformationPresenter.PresentedSymptom(
+            PresentedSymptom(
                 id=symptom.id,
                 appointment_id=symptom.appointment_id,
                 symptom_type_id="lump",
@@ -83,7 +84,7 @@ class TestRecordMedicalInformationPresenter:
         presenter = MedicalInformationPresenter(symptom.appointment)
 
         assert presenter.symptoms == [
-            MedicalInformationPresenter.PresentedSymptom(
+            PresentedSymptom(
                 id=symptom.id,
                 appointment_id=symptom.appointment_id,
                 symptom_type_id="lump",

--- a/manage_breast_screening/mammograms/urls.py
+++ b/manage_breast_screening/mammograms/urls.py
@@ -70,4 +70,9 @@ urlpatterns = [
         symptom_views.ChangeSwellingOrShapeChangeView.as_view(),
         name="change_symptom_swelling_or_shape_change",
     ),
+    path(
+        "<uuid:pk>/record-medical-information/delete_symptom/<uuid:symptom_pk>/",
+        symptom_views.DeleteLump.as_view(),
+        name="delete_symptom",
+    ),
 ]

--- a/manage_breast_screening/mammograms/views/appointment_views.py
+++ b/manage_breast_screening/mammograms/views/appointment_views.py
@@ -182,6 +182,7 @@ class RecordMedicalInformation(InProgressAppointmentMixin, FormView):
                 "presenter": MedicalInformationPresenter(self.appointment),
             }
         )
+
         return context
 
     def form_valid(self, form):

--- a/manage_breast_screening/tests/system/clinical/test_recording_symptoms.py
+++ b/manage_breast_screening/tests/system/clinical/test_recording_symptoms.py
@@ -51,6 +51,16 @@ class TestRecordingSymptoms(SystemTestCase):
         self.then_i_am_back_on_the_medical_information_page()
         self.and_i_see_three_months_to_a_year()
 
+    def test_removing_a_symptom(self):
+        self.given_i_am_logged_in_as_a_clinical_user()
+        self.and_there_is_an_appointment_with_a_symptom_added_in_the_last_three_months()
+        self.and_i_am_on_the_record_medical_information_page()
+        self.when_i_click_on_change()
+        self.and_i_click_on_delete_this_symptom()
+        self.and_i_confirm_i_want_to_delete_the_symptom()
+        self.then_i_am_back_on_the_medical_information_page()
+        self.and_the_lump_is_no_longer_listed()
+
     def and_there_is_an_appointment(self):
         self.participant = ParticipantFactory(first_name="Janet", last_name="Williams")
         self.screening_episode = ScreeningEpisodeFactory(participant=self.participant)
@@ -130,3 +140,15 @@ class TestRecordingSymptoms(SystemTestCase):
         )
         row = self.page.locator(".nhsuk-summary-list__row").filter(has=key)
         expect(row).to_contain_text("3 months to a year")
+
+    def and_i_click_on_delete_this_symptom(self):
+        self.page.get_by_text("Delete this symptom").click()
+
+    def and_i_confirm_i_want_to_delete_the_symptom(self):
+        self.page.get_by_text("Delete symptom").click()
+
+    def and_the_lump_is_no_longer_listed(self):
+        locator = self.page.locator(
+            ".nhsuk-summary-list__key", has=self.page.get_by_text("Lump", exact=True)
+        )
+        expect(locator).not_to_be_attached()


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

This adds a delete link to the bottom of the change form for adding a lump. Once the forms are extended to other symptom types, this will be too.

We decided to implement the interstitial confirmation page now, rather than leave it for later. We definitely want to have a confirmation step, because it's a destructive action that is not easy to undo, but we are thinking about progressively enhancing this to a modal so the interaction feels smoother. ([Jira ticket](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-11111))

We don't have an established pattern for this kind of confirmation page, but there is a GOV.UK one I've used as a starting point: https://govuk-frontend-review.herokuapp.com/full-page-examples/confirm-delete

This is not perfect and will need further tweaks, but I've reviewed it with @edwardhorsford and we're happy it'll do for the purposes of this ticket.

<img width="1005" height="934" alt="Screenshot showing the confirmation page pattern" src="https://github.com/user-attachments/assets/c5971ff9-83cd-4050-bc9e-729e4347bea4" />


## Jira link

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10724

## Review notes

- The copy is currently "delete this symptom" rather than "delete this {symptom type}", for consistency with the prototype. Let me know if you think we should be more specific in the language - I can sort this out as part of extending this to the other types.
