### PR TITLE
use utility classes instead of overriding component styles

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -43,7 +43,3 @@ a[href="#"] {
   right: 0;
   text-align: right;
 }
-
-p:has(+ .app-inset-text) {
-  margin-bottom: 0;
-}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -8,7 +8,7 @@
 {% call card({
   "heading": "Symptoms",
 }) %}
-  <p>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
+  <p{% if not presenter.symptom_rows %} class="nhsuk-u-margin-bottom-3"{% endif %}>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
   {% if presenter.symptom_rows %}
      {{ summaryList({
         "rows": presenter.symptom_rows
@@ -19,7 +19,7 @@
     {% endset %}
     {{ insetText({
       "html": insetHtml,
-      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4 app-inset-text"
+      "classes": "nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
     }) }}
   {% endif %}
 
@@ -89,7 +89,7 @@
     {% endset %}
     {{ insetText({
       "html": insetHtml,
-      "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4 app-inset-text"
+      "classes": "nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4 app-inset-text"
     }) }}
 
     <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">

--- a/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/record_medical_information.jinja
@@ -8,7 +8,7 @@
 {% call card({
   "heading": "Symptoms",
 }) %}
-  <p{% if not presenter.symptom_rows %} class="nhsuk-u-margin-bottom-3"{% endif %}>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
+  <p {%- if not presenter.symptom_rows %} class="nhsuk-u-margin-bottom-3"{% endif %}>Any problems or symptoms, including lumps, swelling, rashes or nipple changes</p>
   {% if presenter.symptom_rows %}
      {{ summaryList({
         "rows": presenter.symptom_rows


### PR DESCRIPTION
## Description
The `p:has()` approach is a bit brittle as it will stop working if other elements come before the inset text.

This is is only used on the record medical info page at the moment, so we can use utility classes to tweak the margins there. We're already applying them to the inset text.

This was suggested by @colinrotherham in another review.

<img width="980" height="294" alt="Screenshot of card with style applied" src="https://github.com/user-attachments/assets/da35cff3-810f-4bd7-960b-af5ec1b30db8" />


## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10724

## Review notes

TBC: if we can live with a margin of 24px (nhsuk-u-margin-bottom-4) following the paragraph, then we can remove the conditional class there that changes it to 16px (nhsuk-u-margin-bottom-3)