### PR TITLE
visually hide `exact_date` legend

### DIFF
--- a/manage_breast_screening/participants/forms.py
+++ b/manage_breast_screening/participants/forms.py
@@ -144,6 +144,7 @@ class ParticipantReportedMammogramForm(forms.Form):
             required=False,
             hint="For example, 15 3 2025",
             label="Date of mammogram",
+            label_classes="nhsuk-u-visually-hidden",
         )
 
         self.fields["approx_date"] = CharField(


### PR DESCRIPTION
Adding this class to match the prototype (noticed while working on something unrelated). Visually, the legend is not needed as it's contextualised by the radio button that reveals it.

<img width="448" height="334" alt="Screenshot of exact date field without the duplicate legend" src="https://github.com/user-attachments/assets/cdd6a22c-632d-41b5-9305-8dcf5efbf0b2" />

