### PR TITLE
[DTOS-10724] fix a few formatting issues in the symptom summary list

### DIFF
--- a/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/presenters/medical_information_presenter.py
@@ -4,7 +4,10 @@ from django.urls import reverse
 
 from manage_breast_screening.core.template_helpers import multiline_content
 from manage_breast_screening.core.utils.date_formatting import format_approximate_date
-from manage_breast_screening.participants.models.symptom import SymptomType
+from manage_breast_screening.participants.models.symptom import (
+    SymptomAreas,
+    SymptomType,
+)
 
 from .appointment_presenters import AppointmentPresenter
 
@@ -22,9 +25,17 @@ class PresentedSymptom:
     stopped_line: str = ""
     additional_information_line: str = ""
 
+    @staticmethod
+    def _present_symptom_area(symptom):
+        if symptom.area == SymptomAreas.OTHER and symptom.area_description:
+            location = f"Other: {symptom.area_description}"
+        else:
+            location = symptom.get_area_display()
+        return location
+
     @classmethod
     def from_symptom(cls, symptom):
-        location = symptom.get_area_display()
+        location = cls._present_symptom_area(symptom)
         started = symptom.get_when_started_display()
         if symptom.year_started is not None and symptom.month_started is not None:
             started = format_approximate_date(

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -46,6 +46,28 @@ class TestRecordMedicalInformationPresenter:
             ),
         ]
 
+    def test_formats_area(self):
+        symptom = SymptomFactory.create(
+            lump=True,
+            when_started=RelativeDateChoices.LESS_THAN_THREE_MONTHS,
+            area=SymptomAreas.OTHER,
+            area_description="abc",
+        )
+
+        presenter = MedicalInformationPresenter(symptom.appointment)
+
+        assert presenter.symptoms == [
+            PresentedSymptom(
+                id=symptom.id,
+                appointment_id=symptom.appointment_id,
+                symptom_type_id="lump",
+                symptom_type_name="Lump",
+                location_line="Other: abc",
+                started_line="Less than 3 months",
+                investigated_line="Not investigated",
+            ),
+        ]
+
     def test_formats_investigation_and_specific_date(self):
         symptom = SymptomFactory.create(
             lump=True,

--- a/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
+++ b/manage_breast_screening/mammograms/tests/presenters/test_medical_information_presenter.py
@@ -41,7 +41,7 @@ class TestRecordMedicalInformationPresenter:
                 symptom_type_id="lump",
                 symptom_type_name="Lump",
                 location_line=expected_location,
-                started_line="Less than 3 months",
+                started_line="Less than 3 months ago",
                 investigated_line="Not investigated",
             ),
         ]
@@ -63,7 +63,7 @@ class TestRecordMedicalInformationPresenter:
                 symptom_type_id="lump",
                 symptom_type_name="Lump",
                 location_line="Other: abc",
-                started_line="Less than 3 months",
+                started_line="Less than 3 months ago",
                 investigated_line="Not investigated",
             ),
         ]
@@ -174,7 +174,7 @@ class TestRecordMedicalInformationPresenter:
                     "text": "Swelling or shape change",
                 },
                 "value": {
-                    "html": "Both breasts<br>Less than 3 months<br>Not investigated",
+                    "html": "Both breasts<br>Less than 3 months ago<br>Not investigated",
                 },
             },
         ]


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

I noticed a couple of bugs in how I'm formatting symptoms in the summary list. The date was missing the "ago" and if area is set to "other" it was missing the details text.

<img width="926" height="138" alt="Screenshot of symptom summary list" src="https://github.com/user-attachments/assets/733cac9c-71b0-4626-a3c0-3c8ab2d7fd2a" />

This is not completely done yet - there will be more changes as part of implementing skin changes and nipple changes.

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10726
