### PR TITLE
Filter clinic list by current_provider

### DIFF
--- a/manage_breast_screening/clinics/models.py
+++ b/manage_breast_screening/clinics/models.py
@@ -31,16 +31,18 @@ class ClinicFilter(StrEnum):
 
 
 class ClinicQuerySet(models.QuerySet):
-    def by_filter(self, filter: str):
+    def by_filter(self, filter: str, provider_id):
+        queryset = self.filter(setting__provider_id=provider_id)
+
         match filter:
             case ClinicFilter.TODAY:
-                return self.today()
+                return queryset.today()
             case ClinicFilter.UPCOMING:
-                return self.upcoming()
+                return queryset.upcoming()
             case ClinicFilter.COMPLETED:
-                return self.completed()
+                return queryset.completed()
             case ClinicFilter.ALL:
-                return self
+                return queryset
             case _:
                 raise ValueError(filter)
 
@@ -121,12 +123,14 @@ class Clinic(BaseModel):
         return {"start_time": self.starts_at, "end_time": self.ends_at}
 
     @classmethod
-    def filter_counts(cls):
+    def filter_counts(cls, provider_id):
+        queryset = cls.objects.filter(setting__provider_id=provider_id)
+
         return {
-            ClinicFilter.ALL: cls.objects.count(),
-            ClinicFilter.TODAY: cls.objects.today().count(),
-            ClinicFilter.UPCOMING: cls.objects.upcoming().count(),
-            ClinicFilter.COMPLETED: cls.objects.completed().count(),
+            ClinicFilter.ALL: queryset.count(),
+            ClinicFilter.TODAY: queryset.today().count(),
+            ClinicFilter.UPCOMING: queryset.upcoming().count(),
+            ClinicFilter.COMPLETED: queryset.completed().count(),
         }
 
     def __str__(self):

--- a/manage_breast_screening/clinics/views.py
+++ b/manage_breast_screening/clinics/views.py
@@ -9,8 +9,11 @@ from .presenters import AppointmentListPresenter, ClinicPresenter, ClinicsPresen
 
 
 def clinic_list(request, filter="today"):
-    clinics = Clinic.objects.prefetch_related("setting").by_filter(filter)
-    counts_by_filter = Clinic.filter_counts()
+    current_provider_id = request.session.get("current_provider")
+    clinics = Clinic.objects.prefetch_related("setting").by_filter(
+        filter, current_provider_id
+    )
+    counts_by_filter = Clinic.filter_counts(current_provider_id)
     presenter = ClinicsPresenter(clinics, filter, counts_by_filter)
     return render(
         request,

--- a/manage_breast_screening/tests/system/general/test_user_views_clinic_show_page.py
+++ b/manage_breast_screening/tests/system/general/test_user_views_clinic_show_page.py
@@ -21,10 +21,11 @@ class TestUserViewsClinicShowPage(SystemTestCase):
     @pytest.fixture(autouse=True)
     def before(self):
         today = datetime.now(timezone.utc).replace(hour=9, minute=0)
-        self.clinic = ClinicFactory(starts_at=today, setting__name="West London BSS")
+        self.clinic_start_time = today
 
     def test_user_views_clinic_show_page(self):
         self.given_i_am_logged_in_as_a_clinical_user()
+        self.and_a_clinic_exists_that_is_run_by_my_provider()
         self.and_there_are_appointments()
         self.and_i_am_on_the_clinic_list()
         self.when_i_click_on_the_clinic()
@@ -44,6 +45,7 @@ class TestUserViewsClinicShowPage(SystemTestCase):
 
     def test_user_views_clinic_show_page_with_special_appointments(self):
         self.given_i_am_logged_in_as_a_clinical_user()
+        self.and_a_clinic_exists_that_is_run_by_my_provider()
         self.and_an_appointment_has_extra_needs()
         self.and_i_am_on_the_clinic_list()
         self.when_i_click_on_the_clinic()
@@ -53,9 +55,18 @@ class TestUserViewsClinicShowPage(SystemTestCase):
 
     def test_accessibility(self):
         self.given_i_am_logged_in_as_a_clinical_user()
+        self.and_a_clinic_exists_that_is_run_by_my_provider()
         self.and_there_are_appointments()
         self.and_i_am_on_the_clinic_show_page()
         self.then_the_accessibility_baseline_is_met()
+
+    def and_a_clinic_exists_that_is_run_by_my_provider(self):
+        user_assignment = self.current_user.assignments.first()
+        self.clinic = ClinicFactory(
+            starts_at=self.clinic_start_time,
+            setting__name="West London BSS",
+            setting__provider=user_assignment.provider,
+        )
 
     def and_there_are_appointments(self):
         self.confirmed_appointment = AppointmentFactory(

--- a/manage_breast_screening/tests/system/system_test_setup.py
+++ b/manage_breast_screening/tests/system/system_test_setup.py
@@ -78,6 +78,7 @@ class SystemTestCase(StaticLiveServerTestCase):
         user = UserFactory.create(groups=[group])
         UserAssignmentFactory.create(user=user)
 
+        self.current_user = user
         self.login_as_user(user)
 
     def expect_validation_error(


### PR DESCRIPTION

<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description
Users should only be able to access resources (such as clinics, appointments) that belong to the user's currently selected provider.

As a starting point, ensure that the clinic list is filtered by provider.

<!-- Add screenshots if there are any UI updates. -->

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10972
## Review notes
There's further work to be done here dealing with:
- Preventing access to resources belonging to other providers (eg — via bookmarks or URL manipulation)
- Role-based authorization

These will be covered in subsequent tickets which deal with adding a per-provider role system.
<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
