### PR TITLE
Symptom form fixes

### DIFF
--- a/manage_breast_screening/mammograms/forms/symptom_forms.py
+++ b/manage_breast_screening/mammograms/forms/symptom_forms.py
@@ -58,6 +58,7 @@ class CommonFields:
         label="Describe when",
         hint="For example, 3 days ago",
         classes="nhsuk-u-width-two-thirds",
+        error_messages={"required": "Enter when the symptom was resolved"},
     )
     investigated = yes_no_field(
         label="Has this been investigated?",
@@ -205,7 +206,7 @@ class SymptomForm(Form):
         investigation_details = self.cleaned_data.get("investigation_details", "")
         intermittent = self.cleaned_data.get("intermittent", False)
         recently_resolved = self.cleaned_data.get("recently_resolved", False)
-        when_resolved = self.cleaned_data.get("when_resolved")
+        when_resolved = self.cleaned_data.get("when_resolved", "")
         additional_information = self.cleaned_data.get("additional_information", "")
 
         return dict(
@@ -261,6 +262,11 @@ class LumpForm(SymptomForm):
             predicate_field_value=RelativeDateChoices.SINCE_A_SPECIFIC_DATE,
         )
         self.set_conditionally_required(
+            conditionally_required_field="when_resolved",
+            predicate_field="recently_resolved",
+            predicate_field_value=True,
+        )
+        self.set_conditionally_required(
             conditionally_required_field="investigation_details",
             predicate_field="investigated",
             predicate_field_value=YesNo.YES,
@@ -309,6 +315,11 @@ class SwellingOrShapeChangeForm(SymptomForm):
             conditionally_required_field="specific_date",
             predicate_field="when_started",
             predicate_field_value=RelativeDateChoices.SINCE_A_SPECIFIC_DATE,
+        )
+        self.set_conditionally_required(
+            conditionally_required_field="when_resolved",
+            predicate_field="recently_resolved",
+            predicate_field_value=True,
         )
         self.set_conditionally_required(
             conditionally_required_field="investigation_details",

--- a/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
@@ -29,6 +29,7 @@
     }
   }) %}
     {{ form.when_started.as_field_group() }}
+    <br>
     {{ form.intermittent.as_field_group() }}
     {{ form.recently_resolved.as_field_group() }}
   {% endcall %}

--- a/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
+++ b/manage_breast_screening/mammograms/jinja2/mammograms/medical_information/symptoms/simple_symptom.jinja
@@ -3,7 +3,7 @@
 {% from "nhsuk/components/fieldset/macro.jinja" import fieldset %}
 
 {% block form %}
-  {% do form.area.add_divider_after("LEFT", "or") %}
+  {% do form.area.add_divider_after("LEFT_BREAST", "or") %}
   {% do form.area.add_conditional_html(
     'OTHER',
     form.area_description.as_field_group()

--- a/manage_breast_screening/mammograms/tests/forms/test_symptom_forms.py
+++ b/manage_breast_screening/mammograms/tests/forms/test_symptom_forms.py
@@ -44,6 +44,7 @@ class TestLumpForm:
                 "area": RightLeftOtherChoices.OTHER,
                 "when_started": RelativeDateChoices.SINCE_A_SPECIFIC_DATE,
                 "investigated": YesNo.YES,
+                "recently_resolved": True,
             }
         )
 
@@ -54,6 +55,7 @@ class TestLumpForm:
             ],
             "specific_date": ["Enter the date the symptom started"],
             "investigation_details": ["Enter details of any investigations"],
+            "when_resolved": ["Enter when the symptom was resolved"],
         }
 
     def test_valid_form_with_conditionally_required_fields(self):
@@ -66,6 +68,8 @@ class TestLumpForm:
                 "specific_date_0": "2",
                 "specific_date_1": "2025",
                 "investigation_details": "def",
+                "recently_resolved": True,
+                "when_resolved": "3 months ago",
             }
         )
         assert form.is_valid()
@@ -191,6 +195,7 @@ class TestSwellingOrShapeChangeForm:
                 "area": RightLeftOtherChoices.OTHER,
                 "when_started": RelativeDateChoices.SINCE_A_SPECIFIC_DATE,
                 "investigated": YesNo.YES,
+                "recently_resolved": True,
             }
         )
 
@@ -201,6 +206,7 @@ class TestSwellingOrShapeChangeForm:
             ],
             "specific_date": ["Enter the date the symptom started"],
             "investigation_details": ["Enter details of any investigations"],
+            "when_resolved": ["Enter when the symptom was resolved"],
         }
 
     def test_valid_form_with_conditionally_required_fields(self):
@@ -213,6 +219,8 @@ class TestSwellingOrShapeChangeForm:
                 "specific_date_0": "2",
                 "specific_date_1": "2025",
                 "investigation_details": "def",
+                "recently_resolved": True,
+                "when_resolved": "3 months ago",
             }
         )
         assert form.is_valid()


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Fix some things that came out of the snagging meeting earlier.

- Conditional validation not working correctly for "when was this symptom resolved?"
- "or" divider went missing because I renamed a value at some point
- add a line break between radios and checkboxes for "how long has this symptom existed?"

## Jira link

## Review notes

There are some other bits related to the form builder components themselves which still need looking at separately, e.g. the date validation gives a funny error message and doesn't highlight both inputs. Also we should make it so that calling `.add_divider_after` in the template errors if you give it an invalid value, or alternatively, come up with a better mechanism for this. 