### PR TITLE
Use Node 22.20

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 pre-commit 3.6.0
 python 3.13.7
-nodejs 22.14.0
+nodejs 22.20.0
 
 # TODO: can we switch all these docker scripts to github actions instead? Or at least something that
 # will be maintained by Dependabot?

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG poetry_version=2.1.2
 
 #### NODE.JS BUILD
 
-FROM node:24.9.0-alpine3.21@sha256:843a738e7405b4fb42b2fc37d6c99cd2063af9f48852968a09851129a96b0ebf AS node_builder
+FROM node:22.20-alpine3.21@sha256:cb3143549582cc5f74f26f0992cdef4a422b22128cb517f94173a5f910fa4ee7 AS node_builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

~* Update dockerfile to use Node 22.14 (instead of 24.*)~
* Update dockerfile to use Node 22.20 (instead of 24.*)
* Update .tool-versions to 22.20

This is the latest LTS version.

