### PR TITLE
Update roles implementation

### DIFF
--- a/manage_breast_screening/auth/management/commands/create_personas.py
+++ b/manage_breast_screening/auth/management/commands/create_personas.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand, CommandError
 
 from manage_breast_screening.clinics.models import Provider, UserAssignment
@@ -24,7 +23,6 @@ class Command(BaseCommand):
             if not provider:
                 raise CommandError("No providers found. Refusing to create.")
             for persona in PERSONAS:
-                group = Group.objects.get(name=persona.group)
                 user, _ = User.objects.get_or_create(
                     nhs_uid=persona.username,
                     defaults={
@@ -32,7 +30,8 @@ class Command(BaseCommand):
                         "last_name": persona.last_name,
                     },
                 )
-                UserAssignment.objects.create(user=user, provider=provider)
-                user.groups.add(group)
+                UserAssignment.objects.create(
+                    user=user, provider=provider, roles=[persona.role.value]
+                )
         except Exception as e:
             raise CommandError(e)

--- a/manage_breast_screening/auth/models.py
+++ b/manage_breast_screening/auth/models.py
@@ -5,7 +5,6 @@ from enum import StrEnum
 class Role(StrEnum):
     ADMINISTRATIVE = "Administrative"
     CLINICAL = "Clinical"
-    SUPERUSER = "Superuser"
 
 
 class Permission(StrEnum):
@@ -26,5 +25,4 @@ class Persona:
 
 ADMINISTRATIVE_PERSONA = Persona("Anna", "Davies", Role.ADMINISTRATIVE)
 CLINICAL_PERSONA = Persona("Chloë", "Robinson", Role.CLINICAL)
-SUPERUSER_PERSONA = Persona("Simon", "O'Brien", Role.SUPERUSER)
-PERSONAS = [ADMINISTRATIVE_PERSONA, CLINICAL_PERSONA, SUPERUSER_PERSONA]
+PERSONAS = [ADMINISTRATIVE_PERSONA, CLINICAL_PERSONA]

--- a/manage_breast_screening/auth/models.py
+++ b/manage_breast_screening/auth/models.py
@@ -16,7 +16,7 @@ class Permission(StrEnum):
 class Persona:
     first_name: str
     last_name: str
-    group: str
+    role: str
 
     @property
     def username(self):

--- a/manage_breast_screening/auth/rules.py
+++ b/manage_breast_screening/auth/rules.py
@@ -10,7 +10,7 @@ from .models import Permission, Role
 
 
 def user_has_any_role(role, *other_roles):
-    roles = [role, *other_roles, Role.SUPERUSER]
+    roles = [role, *other_roles]
 
     @rules.predicate
     def check(user):

--- a/manage_breast_screening/auth/rules.py
+++ b/manage_breast_screening/auth/rules.py
@@ -9,20 +9,25 @@ import rules
 from .models import Permission, Role
 
 
-def user_has_any_role(role, *other_roles):
-    roles = [role, *other_roles]
+@rules.predicate
+def is_clinical(user, provider):
+    if not provider:
+        return False
 
-    @rules.predicate
-    def check(user):
-        # TODO: customise user model to add a cachable role attribute
-        return any(group.name in roles for group in user.groups.all())
-
-    return check
+    return user.assignments.filter(
+        provider=provider, roles__contains=[Role.CLINICAL.value]
+    ).exists()
 
 
-# fmt: off
+@rules.predicate
+def is_administrative(user, provider):
+    if not provider:
+        return False
 
-rules.add_perm(Permission.VIEW_PARTICIPANT_DATA, user_has_any_role(Role.CLINICAL, Role.ADMINISTRATIVE))
-rules.add_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT, user_has_any_role(Role.CLINICAL))
+    return user.assignments.filter(
+        provider=provider, roles__contains=[Role.ADMINISTRATIVE.value]
+    ).exists()
 
-# fmt: on
+
+rules.add_perm(Permission.VIEW_PARTICIPANT_DATA, is_clinical | is_administrative)
+rules.add_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT, is_clinical)

--- a/manage_breast_screening/auth/tests/factories.py
+++ b/manage_breast_screening/auth/tests/factories.py
@@ -30,6 +30,3 @@ class UserFactory(DjangoModelFactory):
 
         if kwargs.get("clinical"):
             self.groups.add(Group.objects.get(name=Role.CLINICAL))
-
-        if kwargs.get("superuser"):
-            self.groups.add(Group.objects.get(name=Role.SUPERUSER))

--- a/manage_breast_screening/auth/tests/test_rules.py
+++ b/manage_breast_screening/auth/tests/test_rules.py
@@ -1,28 +1,111 @@
 import pytest
 
-from manage_breast_screening.auth.models import Permission
+from manage_breast_screening.auth.models import Permission, Role
+from manage_breast_screening.auth.rules import is_administrative, is_clinical
+from manage_breast_screening.clinics.tests.factories import UserAssignmentFactory
 
 
 @pytest.mark.django_db
-class TestRules:
-    def test_rule_requiring_clinical_role(
-        self, user, administrative_user, clinical_user, superuser
-    ):
-        user.groups.add()
+class TestIsClinical:
+    def test_returns_true_for_clinical_assignment(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.CLINICAL])
 
-        assert not user.has_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT)
-        assert not administrative_user.has_perm(
-            Permission.PERFORM_MAMMOGRAM_APPOINTMENT
+        assert is_clinical(user_assignment.user, user_assignment.provider)
+
+    def test_returns_false_when_no_provider(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not is_clinical(user_assignment.user, None)
+
+    def test_returns_false_for_non_clinical_assignment(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.ADMINISTRATIVE])
+
+        assert not is_clinical(user_assignment.user, user_assignment.provider)
+
+    def test_returns_false_for_no_assigned_roles(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not is_clinical(user_assignment.user, user_assignment.provider)
+
+
+@pytest.mark.django_db
+class TestIsAdministrative:
+    def test_returns_true_for_administrative_assignment(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.ADMINISTRATIVE])
+
+        assert is_administrative(user_assignment.user, user_assignment.provider)
+
+    def test_returns_false_when_no_provider(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not is_administrative(user_assignment.user, None)
+
+    def test_returns_false_for_non_administrative_assignment(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.CLINICAL])
+
+        assert not is_administrative(user_assignment.user, user_assignment.provider)
+
+    def test_returns_false_for_no_assigned_roles(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not is_administrative(user_assignment.user, user_assignment.provider)
+
+
+@pytest.mark.django_db
+class TestViewParticipantDataPermission:
+    def test_returns_true_for_clinical_user(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.CLINICAL])
+
+        assert user_assignment.user.has_perm(
+            Permission.VIEW_PARTICIPANT_DATA, user_assignment.provider
         )
-        assert clinical_user.has_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT)
-        assert superuser.has_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT)
 
-    def test_rule_requiring_clinical_or_administrative_role(
-        self, user, administrative_user, clinical_user, superuser
-    ):
-        user.groups.add()
+    def test_returns_true_for_administrative_user(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.ADMINISTRATIVE])
 
-        assert not user.has_perm(Permission.VIEW_PARTICIPANT_DATA)
-        assert administrative_user.has_perm(Permission.VIEW_PARTICIPANT_DATA)
-        assert clinical_user.has_perm(Permission.VIEW_PARTICIPANT_DATA)
-        assert superuser.has_perm(Permission.VIEW_PARTICIPANT_DATA)
+        assert user_assignment.user.has_perm(
+            Permission.VIEW_PARTICIPANT_DATA, user_assignment.provider
+        )
+
+    def test_returns_false_for_user_without_roles(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not user_assignment.user.has_perm(
+            Permission.VIEW_PARTICIPANT_DATA, user_assignment.provider
+        )
+
+    def test_returns_false_if_no_provider_given(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not user_assignment.user.has_perm(Permission.VIEW_PARTICIPANT_DATA, None)
+
+
+@pytest.mark.django_db
+class TestPerformMammogramAppointmentPermission:
+    def test_returns_true_for_clinical_user(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.CLINICAL])
+
+        assert user_assignment.user.has_perm(
+            Permission.PERFORM_MAMMOGRAM_APPOINTMENT, user_assignment.provider
+        )
+
+    def test_returns_false_for_administrative_user(self):
+        user_assignment = UserAssignmentFactory.create(roles=[Role.ADMINISTRATIVE])
+
+        assert not user_assignment.user.has_perm(
+            Permission.PERFORM_MAMMOGRAM_APPOINTMENT, user_assignment.provider
+        )
+
+    def test_returns_false_for_user_without_roles(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not user_assignment.user.has_perm(
+            Permission.PERFORM_MAMMOGRAM_APPOINTMENT, user_assignment.provider
+        )
+
+    def test_returns_false_if_no_provider_given(self):
+        user_assignment = UserAssignmentFactory.create()
+
+        assert not user_assignment.user.has_perm(
+            Permission.PERFORM_MAMMOGRAM_APPOINTMENT, None
+        )

--- a/manage_breast_screening/clinics/jinja2/clinics/select_provider.jinja
+++ b/manage_breast_screening/clinics/jinja2/clinics/select_provider.jinja
@@ -11,6 +11,9 @@
     {% else %}
       <form method="post">
         {{ csrf_input }}
+        {% if next %}
+          <input type="hidden" name="next" value="{{ next }}">
+        {% endif %}
         {% set radioItems = [] %}
         {% for provider in providers %}
           {% do radioItems.append({

--- a/manage_breast_screening/clinics/management/commands/create_assignment.py
+++ b/manage_breast_screening/clinics/management/commands/create_assignment.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 
+from manage_breast_screening.auth.models import Role
 from manage_breast_screening.clinics.models import Provider, UserAssignment
 
 logger = logging.getLogger(__name__)
@@ -70,9 +71,31 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.ERROR("\nOperation cancelled."))
                     return
 
+            roles = list(Role)
+            self.stdout.write("\nAvailable roles:")
+            for i, role in enumerate(roles, 1):
+                self.stdout.write(f"{i}. {role.value}")
+
+            while True:
+                try:
+                    role_choice = input("\nSelect a role (enter number): ").strip()
+                    role_index = int(role_choice) - 1
+                    if 0 <= role_index < len(roles):
+                        selected_role = roles[role_index]
+                        break
+                    else:
+                        self.stdout.write(
+                            self.style.ERROR("Invalid selection. Please try again.")
+                        )
+                except (ValueError, KeyboardInterrupt):
+                    self.stdout.write(self.style.ERROR("\nOperation cancelled."))
+                    return
+
             try:
                 assignment = UserAssignment.objects.create(
-                    user=selected_user, provider=selected_provider
+                    user=selected_user,
+                    provider=selected_provider,
+                    roles=[selected_role.value],
                 )
 
                 self.stdout.write(

--- a/manage_breast_screening/clinics/tests/test_views.py
+++ b/manage_breast_screening/clinics/tests/test_views.py
@@ -1,0 +1,60 @@
+import pytest
+from django.urls import reverse
+
+from manage_breast_screening.auth.models import Role
+
+from .factories import ProviderFactory, UserAssignmentFactory, UserFactory
+
+
+@pytest.mark.django_db
+def test_select_provider_single_assignment_redirects_to_next(client):
+    user = UserFactory()
+    provider = ProviderFactory()
+    UserAssignmentFactory(user=user, provider=provider, roles=[Role.CLINICAL.value])
+
+    client.force_login(user)
+
+    response = client.get(
+        reverse("clinics:select_provider"), {"next": "/clinics/some-target/"}
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/clinics/some-target/"
+    assert client.session["current_provider"] == str(provider.pk)
+
+
+@pytest.mark.django_db
+def test_select_provider_post_redirects_to_next(client):
+    user = UserFactory()
+    provider1 = ProviderFactory()
+    provider2 = ProviderFactory()
+    UserAssignmentFactory(user=user, provider=provider1, roles=[Role.CLINICAL.value])
+    UserAssignmentFactory(user=user, provider=provider2, roles=[Role.CLINICAL.value])
+
+    client.force_login(user)
+
+    response = client.post(
+        reverse("clinics:select_provider"),
+        {"provider": provider2.pk, "next": "/clinics/other-target/"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/clinics/other-target/"
+    assert client.session["current_provider"] == str(provider2.pk)
+
+
+@pytest.mark.django_db
+def test_select_provider_bad_redirect(client):
+    user = UserFactory()
+    provider = ProviderFactory()
+    UserAssignmentFactory(user=user, provider=provider, roles=[Role.CLINICAL.value])
+
+    client.force_login(user)
+
+    response = client.post(
+        reverse("clinics:select_provider"),
+        {"provider": provider.pk, "next": "http://evil.com"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == reverse("clinics:index")

--- a/manage_breast_screening/clinics/views.py
+++ b/manage_breast_screening/clinics/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_http_methods
 
 from ..core.decorators import current_provider_exempt
+from ..core.utils.urls import safe_next_url
 from ..participants.models import Appointment, AppointmentStatus
 from .models import Clinic, Provider
 from .presenters import AppointmentListPresenter, ClinicPresenter, ClinicsPresenter
@@ -57,20 +58,29 @@ def check_in(_request, pk, appointment_pk):
 @current_provider_exempt
 @login_required
 def select_provider(request):
+    next_url = safe_next_url(request)
     user_providers = Provider.objects.filter(assignments__user=request.user)
 
     if len(user_providers) == 1:
         request.session["current_provider"] = str(user_providers.first().pk)
+        if next_url:
+            return redirect(next_url)
         return redirect("clinics:index")
 
     if request.method == "POST":
         provider_id = request.POST.get("provider")
         if provider_id and user_providers.filter(pk=provider_id).exists():
             request.session["current_provider"] = provider_id
+            if next_url:
+                return redirect(next_url)
             return redirect("clinics:index")
 
     return render(
         request,
         "clinics/select_provider.jinja",
-        context={"providers": user_providers, "page_title": "Select Provider"},
+        context={
+            "providers": user_providers,
+            "page_title": "Select Provider",
+            "next": next_url,
+        },
     )

--- a/manage_breast_screening/conftest.py
+++ b/manage_breast_screening/conftest.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import pytest
 from django.test.client import Client
 
+from manage_breast_screening.auth.models import Role
 from manage_breast_screening.auth.tests.factories import UserFactory
 from manage_breast_screening.clinics.tests.factories import UserAssignmentFactory
 
@@ -17,22 +18,15 @@ def user():
 
 @pytest.fixture
 def administrative_user():
-    user = UserFactory.create(nhs_uid="administrative1", groups__administrative=True)
-    UserAssignmentFactory.create(user=user)
+    user = UserFactory.create(nhs_uid="administrative1")
+    UserAssignmentFactory.create(user=user, roles=[Role.ADMINISTRATIVE])
     return user
 
 
 @pytest.fixture
 def clinical_user():
-    user = UserFactory.create(nhs_uid="clinical1", groups__clinical=True)
-    UserAssignmentFactory.create(user=user)
-    return user
-
-
-@pytest.fixture
-def superuser():
-    user = UserFactory.create(nhs_uid="superuser1", groups__superuser=True)
-    UserAssignmentFactory.create(user=user)
+    user = UserFactory.create(nhs_uid="clinical1")
+    UserAssignmentFactory.create(user=user, roles=[Role.CLINICAL])
     return user
 
 
@@ -52,17 +46,6 @@ def administrative_user_client(administrative_user):
     client = Client()
     client.force_login(administrative_user)
     provider = administrative_user.assignments.first().provider
-    session = client.session
-    session["current_provider"] = str(provider.pk)
-    session.save()
-    return client
-
-
-@pytest.fixture
-def superuser_client(superuser):
-    client = Client()
-    client.force_login(superuser)
-    provider = superuser.assignments.first().provider
     session = client.session
     session["current_provider"] = str(provider.pk)
     session.save()

--- a/manage_breast_screening/core/middleware/current_provider.py
+++ b/manage_breast_screening/core/middleware/current_provider.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 
+from manage_breast_screening.clinics.models import Provider
 from manage_breast_screening.core.decorators import is_current_provider_exempt
 
 logger = logging.getLogger(__name__)
@@ -14,12 +15,16 @@ class CurrentProviderMiddleware:
     """Redirects users to provider selection when `current_provider` is missing.
 
     Views can be exempted by decorating them with @current_provider_exempt.
+
+    Also adds a `current_provider` attribute to the request object that lazily
+    loads the Provider instance from the database.
     """
 
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
+        self._add_current_provider_property(request)
         return self.get_response(request)
 
     def process_view(
@@ -36,3 +41,15 @@ class CurrentProviderMiddleware:
             return None
 
         return redirect(reverse("clinics:select_provider"))
+
+    def _add_current_provider_property(self, request: HttpRequest) -> None:
+        """Add current_provider attribute to request.
+
+        Loads the Provider instance from the database based on the
+        current_provider session value.
+        """
+        provider_id = request.session.get("current_provider")
+        if provider_id:
+            request.current_provider = Provider.objects.get(pk=provider_id)
+        else:
+            request.current_provider = None

--- a/manage_breast_screening/core/utils/urls.py
+++ b/manage_breast_screening/core/utils/urls.py
@@ -1,0 +1,15 @@
+def safe_next_url(request):
+    """Extract and validate a 'next' URL from request GET or POST parameters.
+
+    Only returns the URL if it's a safe relative URL (starts with '/').
+    Returns None if no valid next URL is found.
+    """
+    next_candidate = request.POST.get("next") or request.GET.get("next")
+
+    if not next_candidate:
+        return None
+
+    if next_candidate.startswith("/"):
+        return next_candidate
+
+    return None

--- a/manage_breast_screening/mammograms/views/appointment_views.py
+++ b/manage_breast_screening/mammograms/views/appointment_views.py
@@ -45,7 +45,10 @@ class ShowAppointment(AppointmentMixin, View):
     def get(self, request, *args, **kwargs):
         appointment = self.appointment
         if (
-            request.user.has_perm(Permission.PERFORM_MAMMOGRAM_APPOINTMENT)
+            request.user.has_perm(
+                Permission.PERFORM_MAMMOGRAM_APPOINTMENT,
+                request.current_provider,
+            )
             and appointment.current_status.in_progress
         ):
             return redirect("mammograms:start_screening", pk=self.appointment.pk)

--- a/manage_breast_screening/mammograms/views/mixins.py
+++ b/manage_breast_screening/mammograms/views/mixins.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import get_object_or_404, redirect
+from rules.contrib.views import PermissionRequiredMixin
 
 from manage_breast_screening.auth.models import Permission
 from manage_breast_screening.participants.models import Appointment
@@ -35,6 +35,9 @@ class InProgressAppointmentMixin(PermissionRequiredMixin, AppointmentMixin):
     """
 
     permission_required = Permission.PERFORM_MAMMOGRAM_APPOINTMENT
+
+    def get_permission_object(self):
+        return self.request.current_provider
 
     def dispatch(self, request, *args, **kwargs):
         appointment = self.appointment  # type: ignore

--- a/manage_breast_screening/participants/tests/test_views.py
+++ b/manage_breast_screening/participants/tests/test_views.py
@@ -12,7 +12,6 @@ def participant():
 @pytest.mark.django_db
 class TestShowParticipant:
     def test_renders_response(self, clinical_user_client, participant):
-        clinical_user_client.login()
         response = clinical_user_client.get(
             reverse("participants:show", kwargs={"pk": participant.pk}),
         )

--- a/manage_breast_screening/participants/views.py
+++ b/manage_breast_screening/participants/views.py
@@ -1,11 +1,9 @@
 from logging import getLogger
 from urllib.parse import urlparse
 
-from django.contrib.auth.decorators import permission_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
-from manage_breast_screening.auth.models import Permission
 from manage_breast_screening.mammograms.presenters import LastKnownMammogramPresenter
 from manage_breast_screening.participants.services import fetch_most_recent_provider
 
@@ -33,7 +31,6 @@ def parse_return_url(request, default: str) -> str:
     return return_url
 
 
-@permission_required(Permission.VIEW_PARTICIPANT_DATA)
 def show(request, pk):
     participant = get_object_or_404(Participant, pk=pk)
     presented_participant = ParticipantPresenter(participant)
@@ -76,7 +73,6 @@ def show(request, pk):
     )
 
 
-@permission_required(Permission.VIEW_PARTICIPANT_DATA)
 def edit_ethnicity(request, pk):
     participant = get_object_or_404(Participant, pk=pk)
 
@@ -110,7 +106,6 @@ def edit_ethnicity(request, pk):
     )
 
 
-@permission_required(Permission.VIEW_PARTICIPANT_DATA)
 def add_previous_mammogram(request, pk):
     participant = get_object_or_404(Participant, pk=pk)
     most_recent_provider = fetch_most_recent_provider(pk)

--- a/manage_breast_screening/tests/system/system_test_setup.py
+++ b/manage_breast_screening/tests/system/system_test_setup.py
@@ -121,9 +121,6 @@ class SystemTestCase(StaticLiveServerTestCase):
     def given_i_am_logged_in_as_an_administrative_user(self):
         self.login_as_role(Role.ADMINISTRATIVE)
 
-    def given_i_am_logged_in_as_an_superuser(self):
-        self.login_as_role(Role.SUPERUSER)
-
     def then_the_accessibility_baseline_is_met(self, require_unique_link_text=True):
         """
         Check for certain accessibility issues that can be detected automatically without

--- a/manage_breast_screening/tests/system/system_test_setup.py
+++ b/manage_breast_screening/tests/system/system_test_setup.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 import pytest
 from django.conf import settings
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -74,9 +74,8 @@ class SystemTestCase(StaticLiveServerTestCase):
         Emulate logging in as a user having a particular role,
         without needing to visit a login page.
         """
-        group, _created = Group.objects.get_or_create(name=role)
-        user = UserFactory.create(groups=[group])
-        UserAssignmentFactory.create(user=user)
+        user = UserFactory.create()
+        UserAssignmentFactory.create(user=user, roles=[role.value])
 
         self.current_user = user
         self.login_as_user(user)


### PR DESCRIPTION
<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description
Our current permissions model was an early version built around Django
groups.

We've now iterated our requirements for permissions and want to build
out something based on Clinical and Administrative user roles that can
be set on each Provider assignment.

Because we want to set roles per provider, it's easier to build
something custom rather than continue to rely on groups, which don't
align well with the model we have in mind.

This PR contains updates to the rules files and various associated changes. Highlights:

- `is_administrative` and `is_clinical` rule predicates that check the relationship between a user and provider, including inspection of the assigned role
- Rework next url at persona login so that we account for the select-provider redirect that's been introduced to the login flow
- Make `current_provider` available on the `request` object 
- Remove the concept of a superuser
- Update permissions checks for PERFORM_MAMMOGRAM_APPOINTMENT
- Remove permission checks for VIEW_PARTICIPANT_DATA

<!-- Add screenshots if there are any UI updates. -->

## Jira link
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10979
## Review notes
- The reworked predicates mean that a provider must be provided whenever evaluating permissions in order for the check to pass
- Does the rationale for removing VIEW_PARTICIPANT_DATA checks make sense? Do we still need to keep this permission in the codebase?
- Related to the above — something that's missing here is ensuring that a user has at least one role specified on their assignment. It's an edge case that we should cover, and I'll raise it in a followup PR.
<!-- Add notable context, discussion items, and anything else that would be helpful for a reviewer to know. -->
