### PR TITLE
Run build step straight away in CI

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
   build-stage:
     name: 'Build stage'
-    needs: [metadata, test-stage]
+    needs: [metadata]
     uses: ./.github/workflows/stage-3-build.yaml
     with:
       build_datetime: '${{ needs.metadata.outputs.build_datetime }}'


### PR DESCRIPTION
Our CI currently waits until all tests have run before attempting to build the image. There is some logic to this - if the tests fail, you might not want the image to end up in the image repository.

However, we would never use one of these bad images in production, because the deploy to non-review environments is fully automated, and it's triggered by a separate workflow that runs against the main branch, and still requires all the tests to run first.

I'm proposing removing this requirement so that CI finishes quicker, and we are not blocked from deploying review apps while the test suite runs. Sometimes you might want to deploy something that fails some linter or whatever, as this can be done in parallel to people looking at the review app.
