### PR TITLE
[DTOSS-11202] - feat: add Monitoring Contributor RBAC for ADO-to-Azure managed identity

### DIFF
--- a/infrastructure/terraform/resource_group_init/main.bicep
+++ b/infrastructure/terraform/resource_group_init/main.bicep
@@ -28,6 +28,7 @@ var miGHtoADOname = 'mi-${appShortName}-${envConfig}-ghtoado-uks'
 var roleID = {
   CDNContributor: 'ec156ff8-a8d1-4d15-830c-5b80698ca432'
   kvSecretsUser: '4633458b-17de-408a-b874-0445c86b69e6'
+  monitoringContributor: '749f88d5-cbae-40b8-bcfc-e573ddc772fa'
   networkContributor: '4d97b98b-1d4f-4787-a291-c67834d212e7'
   rbacAdmin: 'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
   reader: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
@@ -121,6 +122,16 @@ module storageAccountPrivateEndpoint 'privateEndpoint.bicep' = {
     resourceServiceType: 'storage'
     resourceID: terraformStateStorageAccount.outputs.storageAccountID
     privateDNSZoneID: storagePrivateDNSZone.outputs.privateDNSZoneID
+  }
+}
+
+// Let the managed identity manage monitoring resources (Application Insights, Log Analytics)
+resource monitoringContributorAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().subscriptionId, envConfig, 'monitoringContributor')
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleID.monitoringContributor)
+    principalId: managedIdentiyADOtoAZ.outputs.miPrincipalID
+    description: '${miADOtoAZname} Monitoring Contributor access to subscription'
   }
 }
 


### PR DESCRIPTION

<!-- Prefix the PR title with the Jira issue number in square brackets (eg - [DTOSS-XXXX]), if applicable -->

## Description

Implements comprehensive monitoring infrastructure for the breast screening application by adding Application Insights integration and the necessary RBAC permissions for the ADO-to-Azure managed identity to manage monitoring resources.

**Infrastructure Changes:**
- Added `monitoringContributor` role definition ID (`749f88d5-cbae-40b8-bcfc-e573ddc772fa`)
- Created `monitoringContributorAssignment` resource with subscription-level scope
- Grants managed identity `mi-manbrs-{env}-adotoaz-uks` permissions to manage:
  - Application Insights instances
  - Log Analytics workspaces  
  - Monitoring alerts and dashboards
  - Diagnostic settings and metrics

**Security Implementation:**
- Follows principle of least privilege with specific monitoring permissions
- Maintains separation of concerns alongside existing role assignments:
  - `CDNContributor` - Front Door management
  - `networkContributor` - VNet and DNS management
  - `rbacAdmin` - Constrained Key Vault role assignments only
- Uses GUID-based assignment names for idempotent deployments

**Integration Benefits:**
- Enables Terraform deployment of Application Insights resources
- Supports Azure Monitor Private Link Scope (AMPLS) configuration
- Facilitates secure monitoring data collection through private endpoints
- Maintains compliance with NHS Digital security requirements

## Jira link

[Link to Jira ticket]

## Review notes

**RBAC Architecture:**
- **Direct permissions** for resource management (monitoring, network, CDN)
- **Constrained RBAC Admin** for specific role assignments (Key Vault only)
- Clean separation prevents permission escalation whilst enabling monitoring deployment

**Deployment Impact:**
- Zero downtime - additive RBAC assignment only
- Idempotent deployment using subscription + environment GUID
- Compatible with existing managed identity federation and authentication

**Testing Verification:**
- Confirm managed identity can deploy Application Insights via Terraform
- Validate monitoring data collection through private endpoints
- Verify AMPLS integration for secure telemetry ingestion

**Post-Deployment:**
- Application Insights resources can be deployed via existing Terraform pipelines
- Container apps can be configured with monitoring connection strings
- Monitoring dashboards and alerts can be established

This change enables the monitoring infrastructure deployment whilst maintaining the established security model and RBAC separation of concerns.